### PR TITLE
added setOptions to smarty engine

### DIFF
--- a/Library/Phalcon/Mvc/View/Engine/Smarty.php
+++ b/Library/Phalcon/Mvc/View/Engine/Smarty.php
@@ -51,5 +51,16 @@ class Smarty extends Engine implements EngineInterface
         }
         $this->_view->setContent($this->_smarty->fetch($path));
     }
+    
+	/**
+	 * Set Smarty's options
+	 *
+	 * @param array $options
+	 */
+	public function setOptions(array $options) {
+		foreach ($options as $k => $v) {
+			 $this->_smarty->$k = $v;
+		}
+	}
 
 }


### PR DESCRIPTION
example:

``` php
$di->set('view', function() use ($config) {

    $view = new \Phalcon\Mvc\View();
    $view->setViewsDir($config->application->viewsDir);

    $view->registerEngines(
        array('.html' => function($view, $di) {

                require_once '../app/vendors/Smarty-3.1.13/libs/Smarty.class.php';

                $smarty = new \Phalcon\Mvc\View\Engine\Smarty($view, $di);

                $smarty->setOptions(array(
                    'template_dir'      => $view->getViewsDir(),
                    'compile_dir'       => '../app/viewscompiled',
                    'error_reporting'   => error_reporting() ^ E_NOTICE,
                    'escape_html'       => true,
                    '_file_perms'       => 0666,
                    '_dir_perms'        => 0777,
                    'force_compile'     => false,
                    'compile_check'     => true,
                    'caching'           => false,
                    'debugging'         => true,
                ));

                return $smarty;
            }
        )
    );
```
