### PR TITLE
Fix -> Contents are not output when cache fault.

### DIFF
--- a/Library/Phalcon/Cache/Backend/Redis.php
+++ b/Library/Phalcon/Cache/Backend/Redis.php
@@ -107,6 +107,8 @@ class Redis extends Backend implements BackendInterface
 		}
 
 		$options['redis']->setex($lastKey, $lifetime, $frontend->beforeStore($content));
+		
+		$isBuffering = $frontend->isBuffering();
 
 		//Stop the buffer, this only applies for Phalcon\Cache\Frontend\Output
 		if ($stopBuffer) {
@@ -114,7 +116,7 @@ class Redis extends Backend implements BackendInterface
 		}
 
 		//Print the buffer, this only applies for Phalcon\Cache\Frontend\Output
-		if ($frontend->isBuffering()) {
+		if ($isBuffering) {
 			echo $content;
 		}
 


### PR DESCRIPTION
When first output (cache fault), contents are not output.
Because the value of $frontend->isBuffering() always returns false
after called $frontend->stop().

Get the value of $frontend->isBuffering() before call $frontend->stop().
