### PR TITLE
fix mustache engine for 1.2.3

### DIFF
--- a/Library/Phalcon/Mvc/View/Engine/Mustache.php
+++ b/Library/Phalcon/Mvc/View/Engine/Mustache.php
@@ -23,10 +23,10 @@ class Mustache extends Engine implements EngineInterface
      * @param \Phalcon\Mvc\ViewInterface $view
      * @param \Phalcon\DiInterface $di
      */
-    public function __construct($view,  $di)
+    public function __construct($view, $dependencyInjector = null)
     {
         $this->_mustache = new \Mustache_Engine();
-        parent::__construct($view, $di);
+        parent::__construct($view, $dependencyInjector);
     }
 
     /**


### PR DESCRIPTION
Otherwise i see:

```
Fatal error: Declaration of Phalcon\Mvc\View\Engine\Mustache::__construct() must be compatible with Phalcon\Mvc\View\EngineInterface::__construct($view, $dependencyInjector = NULL)
```
