### PR TITLE
Enabling use of incubator with latest phalcon beta version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.6",
-        "ext-phalcon": "1.2.4"
+        "ext-phalcon": ">=1.2.4"
     },
     "autoload": {
         "psr-0" : {


### PR DESCRIPTION
Lately you added requirement for Phlacon version to the composer, which is great, however it breaks updates in case one has pre-released Phalcon installed.

I suggest version is limited downwards-only.
