### PR TITLE
Adding a new way to deal with texts/words

### DIFF
--- a/Library/Phalcon/Utils/README.md
+++ b/Library/Phalcon/Utils/README.md
@@ -1,27 +1,94 @@
-
-Phalcon\Utils
+﻿Phalcon\Utils\Text
 =============
+This *static* class is responsible to help you to deal with words, texts, sentences and phrases.
 
-Utility functions:
-
-Slug
-----
+Slugify
+---
 Creates a slug for the passed string taking into account international characters.
 
-Examples
---------
-```
-use \Phalcon\Utils\Slug as PhSlug;
-
-echo PhSlug::generate("Mess'd up --text-- just (to) stress /test/ ?our! `little` \\clean\\ url fun.ction!?-->");
-returns: messd-up-text-just-to-stress-test-our-little-clean-url-function
-
-echo PhSlug::generate("Perché l'erba è verde?", "'"); // Italian
-returns: perche-l-erba-e-verde
-```
-
+### Requeriments
 The extension [iconv](http://php.net/manual/en/book.iconv.php) must be installed in PHP.
 
+### Examples
+```php
+use \Phalcon\Utils\Text as Text;
+
+// Output: messd-up-text-just-to-stress-test-our-little-clean-url-function
+echo Text::slugify
+        ("Mess'd up --text-- just (to) stress /test/ ?our! `little` \\clean\\ url fun.ction!?-->");
+
+// The following expression will echo: perche-l-erba-e-verde
+echo Text::slugify("Perché l'erba è verde?", "'");
+```
+
+Pluralize
+---
+Returns a pluralized word (or not) based on an array.
+
+### Examples
+```php
+use \Phalcon\Utils\Text as Text;
+
+// A simple array with three values.
+$consoles = ['Xbox One', 'Playstation 4', 'WiiU'];
+
+// Output: "There is/are 3 consoles available."
+echo 'There is/are ' . count($consoles) . ' ' . Text::pluralize($consoles, 'console') . ' available.';
+```
+
+```php
+// Another simple array with one value.
+$todaysPosts = ['Nelson Mandela dies at 95'];
+
+// Output: "Found 1 post today."
+echo 'Found ' . count($postsForToday) . ' ' . Text::pluralize($todaysPosts, 'post') . ' today.';
+```
+
+Integrating with Volt
+---
+To integrate with [Volt Template Engine](http://docs.phalconphp.com/en/latest/reference/volt.html) you just need to add the function that you want to use in your DI.
+
+To do this, go to your Volt's DI (probably in `/public/index.php`), and just add a function to the engine. See:
+
+```php
+// This file is "/public/index.php", where I manage all DIs.
+
+// ...
+    $di->set('voltService', function($view, $di) {
+        $volt = new Volt($view, $di);
+        
+        // your implementation goes here...
+        
+        $compiler = $volt->getCompiler();
+        
+        $compiler->addFunction('pluralize', function($resolvedArgs, $exprArga) {
+            return 'Phalcon\Utils\Text::pluralize(' . $resolvedArgs . ')';
+        });
+        
+        // more of yours' implementation...
+        
+        return $volt;
+    });
+// ...
+```
+
+Then, in your view:
+
+```html+php
+<html>
+    <head><!-- Your application's head here --></head>
+    <body>
+        There is/are 
+        {{ consolesQuantity }} {{ pluralize(['Xbox One', 'Playstation 4'], 'console') }}  
+        available.
+    </body>
+</html>
+```
+
+To learn more about Volt's functions, [just read the documentation](http://docs.phalconphp.com/en/latest/reference/volt.html#functions).
+
+***
 Credits
--------
-Matteo Spinelli (http://cubiq.org) [php-clean-url-generator](http://cubiq.org/the-perfect-php-clean-url-generator)
+----
+* Matteo Spinelli (http://cubiq.org) [php-clean-url-generator](http://cubiq.org/the-perfect-php-clean-url-generator)
+* Guilherme Oderdenge ([email](mailto:guilhermeoderdenge@gmail.com), [twitter](http://twitter.com/chiefgui) & [site](http://vincae.com))

--- a/Library/Phalcon/Utils/Text.php
+++ b/Library/Phalcon/Utils/Text.php
@@ -4,7 +4,7 @@
   +------------------------------------------------------------------------+
   | Phalcon Framework                                                      |
   +------------------------------------------------------------------------+
-  | Copyright (c) 2011-2012 Phalcon Team (http://www.phalconphp.com)       |
+  | Copyright (c) 2011-2013 Phalcon Team (http://www.phalconphp.com)       |
   +------------------------------------------------------------------------+
   | This source file is subject to the New BSD License that is bundled     |
   | with this package in the file docs/LICENSE.txt.                        |
@@ -18,12 +18,12 @@
   +------------------------------------------------------------------------+
   | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
   |          Nikolaos Dimopoulos <nikos@niden.net>                         |
-  +------------------------------------------------------------------------+
-*/
+  +
+ */
 
 namespace Phalcon\Utils;
 
-class Slug
+class Text
 {
     /**
      * Creates a slug to be used for pretty URLs
@@ -36,7 +36,7 @@ class Slug
      *
      * @return mixed
      */
-    public static function generate($string, $replace = array(), $delimiter = '-')
+    public static function slugify($string, $replace = array(), $delimiter = '-')
     {
 
         if (!extension_loaded('iconv'))
@@ -63,5 +63,18 @@ class Slug
         setlocale(LC_ALL, $oldLocale);
 
         return $clean;
+    }  
+  
+    /**
+     * Pluralize a word automatically.
+     * 
+     * @param   array   $matrix
+     * @param   string  $word
+     * 
+     * @return  string
+     */
+    public static function pluralize(array $matrix, $word)
+    {
+        if (count($matrix) != 1) return $word . 's'; else return $word;
     }
 }

--- a/README.md
+++ b/README.md
@@ -115,4 +115,4 @@ $loader->register();
 * [Phalcon\Session\Adapter\HandlerSocket](https://github.com/phalcon/incubator/tree/master/Library/Phalcon/Session/Adapter) - HandlerSocket adapter for storing sessions (Xrymz)
 
 ### Utils
-* [Phalcon\Utils\Slug](https://github.com/phalcon/incubator/tree/master/Library/Phalcon/Utils) - Creates a slug for the passed string taking into account international characters. (niden)
+* [Phalcon\Utils\Text](https://github.com/phalcon/incubator/tree/master/Library/Phalcon/Text) - A mechanism that facilitates dealing with words, texts, sentences and phrases. You can slugify or pluralize something with this, for example.


### PR DESCRIPTION
Hello!

I'm here to propose a new way to deal with words in Phalcon. Now, Slug.php is Text.php and the scope of this mechanism is bigger than ever!

Regardless of this situation, I'm bringing to Phalcon a very useful feature called "pluralize" (read the docs to learn more) that was [requested by a user](http://forum.phalconphp.com/discussion/195/plural-in-nativearray-) a long time ago.

_All documentation and implementation is ready-to-go._
