### PR TITLE
ignoreTube method added @ incubator/Library/Phalcon/Queue/Beanstalk/Exte...

### DIFF
--- a/Library/Phalcon/Queue/Beanstalk/Extended.php
+++ b/Library/Phalcon/Queue/Beanstalk/Extended.php
@@ -263,12 +263,13 @@ class Extended extends Base
 		$result = null;
 		$lines  = $this->getResponseLinesText('ignore ' . $this->getTubeName($tube));
 
-		if (null !== $lines) {            
+		if (null !== $lines) {
 			list($name, $value) = explode(' ', $lines);
 			if (null !== $value) {
 				$result[$name] = intval($value);
 			}
 		}
+
 		return $result;
 	}
 
@@ -325,11 +326,12 @@ class Extended extends Base
 
 			if (!preg_match('#^WATCHING (\d+).*?#', $response, $matches)) {
 				throw new \RuntimeException(sprintf(
-				'Unhandled response: %s',
-				$response
-			));
+					'Unhandled response: %s',
+					$response
+				));
 			}
-		$result = $response;
+
+			$result = $response;
 		}
 
 		return $result;


### PR DESCRIPTION
Hi Team,

I have added ignoreTube as well as getResponseLinesText method @ incubator/Library/Phalcon/Queue/Beanstalk/Extended.php as per beanstalk protocol defination (https://github.com/kr/beanstalkd/blob/master/doc/protocol.txt) to ignore any watched tube.

It is working fine at my laptop and server. Please review and provide this feature to rest of world.

Thanks in advance for providing such a great framework.

Regards
Tapan Thapa
