### PR TITLE
Easing off the dependencies (Phalcon, PHPUnit)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
     ],
     "require": {
         "php": ">=5.3.6",
-        "ext-phalcon": ">=1.2.4,<1.3"
+        "ext-phalcon": ">=1.2.4,<2"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.28",
+        "phpunit/phpunit": "3.7.*",
         "squizlabs/php_codesniffer": "1.*",
         "codeception/codeception": "*"
     },


### PR DESCRIPTION
Current version is impossible to install with Phalcon 1.3 and I assume until 2.0 the API is not changing dramatically. Let's have support for ongoing releases. PHPUnit API is also not going anywhere between minor versions.
