### PR TITLE
Fix logInternal

### DIFF
--- a/Library/Phalcon/Logger/Adapter/Database.php
+++ b/Library/Phalcon/Logger/Adapter/Database.php
@@ -58,7 +58,7 @@ class Database extends \Phalcon\Logger\Adapter implements \Phalcon\Logger\Adapte
      * @param integer $time
      * @param array   $context
      */
-    public function logInternal($message, $type, $time, $context)
+    public function logInternal($message, $type, $time, $context = array())
     {
         return $this->options['db']->execute(
             'INSERT INTO ' . $this->options['table'] . ' VALUES (null, ?, ?, ?, ?)',

--- a/Library/Phalcon/Logger/Adapter/File/Multiple.php
+++ b/Library/Phalcon/Logger/Adapter/File/Multiple.php
@@ -71,7 +71,7 @@ class Multiple extends \Phalcon\Logger\Adapter\File implements \Phalcon\Logger\A
      * @param  array                     $context
      * @throws \Phalcon\Logger\Exception
      */
-    public function logInternal($message, $type, $time, $context)
+    public function logInternal($message, $type, $time, $context = array())
     {
         $filename = $this->path .
             \DIRECTORY_SEPARATOR .

--- a/Library/Phalcon/Logger/Adapter/Firelogger.php
+++ b/Library/Phalcon/Logger/Adapter/Firelogger.php
@@ -133,7 +133,7 @@ class Firelogger extends \Phalcon\Logger\Adapter implements \Phalcon\Logger\Adap
      * @param integer $time
      * @param array   $context
      */
-    public function logInternal($message, $type, $time, $context)
+    public function logInternal($message, $type, $time, $context = array())
     {
         if (!$this->enabled) {
             return;


### PR DESCRIPTION
fix Phalcon\Logger\Exception**::logInternal signature not matching Phalcon\Logger\Adapter::logInternal.
I ran into this issue after upgrading to v1.3.0 of Phalcon.
