### PR TITLE
Fix error in header parsing

### DIFF
--- a/Library/Phalcon/Http/Client/Header.php
+++ b/Library/Phalcon/Http/Client/Header.php
@@ -136,7 +136,7 @@ class Header implements \Countable
 
         foreach ($content as $field) {
             if (!is_array($field)) {
-                $field = array_map('trim', explode(':', $field));
+                $field = array_map('trim', explode(':', $field, 2));
             }
 
             if (count($field) == 2) {


### PR DESCRIPTION
When a header contains "Location: http://www.google.fr/", the location is not parsed in the header list
