### PR TITLE
Twig: multiple fixes + new function url()

### DIFF
--- a/Library/Phalcon/Mvc/View/Engine/Twig.php
+++ b/Library/Phalcon/Mvc/View/Engine/Twig.php
@@ -114,6 +114,9 @@ class Twig extends Engine implements EngineInterface
             }, $options),
             new \Twig_SimpleFunction('getSecurityTokenKey', function () use ($di) {
                 return $di->get("security")->getTokenKey();
+            }, $options),
+            new \Twig_SimpleFunction('url', function ($route) use ($di) {
+                return $di->get("url")->get($route);
             }, $options)
         );
 


### PR DESCRIPTION
Some of the functions that use the DependencyInjector in the twig "bundle" did not work for me, i was getting this error:

```
Using $this when not in object context in /[..]/app/incubator/Mvc/View/Engine/Twig.php
```

The issue was the use of $this inside the closure passed to Twig_SimpleFunction()

I also added an "url" function that is already available to the volt engine.
