### PR TITLE
change array short syntax [] to full syntax for supporting PHP5.3

### DIFF
--- a/Library/Phalcon/Queue/Beanstalk/Extended.php
+++ b/Library/Phalcon/Queue/Beanstalk/Extended.php
@@ -157,7 +157,7 @@ class Extended extends Base
     public function putInTube($tube, $data, $options = null)
     {
         if (null === $options) {
-            $options = [];
+            $options = array();
         }
 
         if (!array_key_exists('delay', $options)) {
@@ -198,7 +198,7 @@ class Extended extends Base
      */
     public function getTubes()
     {
-        $result = [];
+        $result = array();
         $lines = $this->getResponseLines('list-tubes');
 
         if (null !== $lines) {
@@ -293,7 +293,7 @@ class Extended extends Base
 
         if ($nbBytes && ($nbBytes > 0)) {
             $response = $this->read($nbBytes);
-            $matches = [];
+            $matches = array();
 
             if (!preg_match('#^(OK (\d+))#mi', $response, $matches)) {
                 throw new \RuntimeException(sprintf(
@@ -334,7 +334,7 @@ class Extended extends Base
 
         if ($nbBytes && ($nbBytes > 0)) {
             $response = $this->read($nbBytes);
-            $matches  = [];
+            $matches  = array();
 
             if (!preg_match('#^WATCHING (\d+).*?#', $response, $matches)) {
                 throw new \RuntimeException(sprintf(

--- a/Library/Phalcon/Translate/Adapter/Csv.php
+++ b/Library/Phalcon/Translate/Adapter/Csv.php
@@ -24,11 +24,11 @@ class Csv extends Adapter implements AdapterInterface
             throw new \Exception('Parameter "file" is required.');
         }
 
-        $default = [
+        $default = array(
             'delimiter' => ';',
             'length'    => 0,
             'enclosure' => '"',
-        ];
+        );
 
         $options = array_merge($default, $options);
         if (false === ($file = @fopen($options['file'], 'rb'))) {


### PR DESCRIPTION
Hi Guys

I changed all short array syntax `[]` to full syntax `array()` in order to support PHP5.3.  because composer.json said incubator could support `"php": ">=5.3.6"`.  Also I think PHP5.3 should be support for a little more time, such as Ubuntu 12.04LTS stardard php version is 5.3.10
