### PR TITLE
Fix composer autoload declaration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "autoload": {
         "psr-0": {
-            "Phalcon": "Library/"
+            "Phalcon": "Library/Phalcon/"
         }
     }
 


### PR DESCRIPTION
We can't use composer autoload due to this bad declaration.
