### PR TITLE
Making destroy() compatible with AdapterInterface

### DIFF
--- a/Library/Phalcon/Session/Adapter/Mongo.php
+++ b/Library/Phalcon/Session/Adapter/Mongo.php
@@ -114,10 +114,13 @@ class Mongo extends Adapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function destroy()
+    public function destroy($session_id = null)
     {
+        if (null === $session_id) {
+            $session_id = session_id();
+        }
         $options = $this->getOptions();
-        $sessionData = $options['collection']->findOne(array('session_id' => session_id()));
+        $sessionData = $options['collection']->findOne(array('session_id' => $session_id));
         if (is_array($sessionData)) {
             $options['collection']->remove($sessionData);
         }


### PR DESCRIPTION
Fixes error: Declaration of Phalcon\Session\Adapter\Mongo::destroy() must be compatible with Phalcon\Session\AdapterInterface::destroy($session_id = NULL)
