### PR TITLE
Fixes "Invalid MetaData" Exception in Mvc/Model/MetaData/Redis.php

### DIFF
--- a/Library/Phalcon/Mvc/Model/MetaData/Redis.php
+++ b/Library/Phalcon/Mvc/Model/MetaData/Redis.php
@@ -66,4 +66,25 @@ class Redis extends Base
 
         return $this->redis;
     }
+    
+    /**
+     * {@inheritdoc}
+     * @param  string $key
+     * @return array
+     */
+    public function read($key)
+    {
+        return parent::read($key) ?: null;
+    }
+    
+    /**
+     * Returns the sessionId with prefix
+     *
+     * @param  string $id
+     * @return string
+     */
+    protected function getId($id)
+    {
+        return str_replace('\\', ':', parent::getId($id));
+    }
 }


### PR DESCRIPTION
Hello there.

The current implementation does not work properly, as most redis wrapper return `false` instead of `null` when no key is found (see e.g. https://github.com/nicolasff/phpredis#get).

Furthermore, the current keys are directory (`foo\bar\baz`) and not "redis" style (`foo:bar:baz`).
