### PR TITLE
Redis cache adapter should remove only keys with its prefix

### DIFF
--- a/Library/Phalcon/Cache/Backend/Redis.php
+++ b/Library/Phalcon/Cache/Backend/Redis.php
@@ -179,7 +179,7 @@ class Redis extends Prefixable
     public function flush()
     {
         $options = $this->getOptions();
-
-        return $options['redis']->flushAll();
+        $keys = $options['redis']->keys($this->getPrefixedIdentifier('*'));
+        return $options['redis']->delete($keys);
     }
 }


### PR DESCRIPTION
When calling flush method from a backend cache adapter, it should keep all the keys from other configuration. When you have two configurations using the same redis server, it cannot delete other keys than the ones with the prefix of the called configuration.
