### PR TITLE
Removed duplicate validation message being added

### DIFF
--- a/Library/Phalcon/Mvc/Model/Validator/ConfirmationOf.php
+++ b/Library/Phalcon/Mvc/Model/Validator/ConfirmationOf.php
@@ -30,7 +30,6 @@ class ConfirmationOf extends \Phalcon\Mvc\Model\Validator
 
         if ($fieldConfirmationValue) {
             if ($fieldValue !== $fieldConfirmationValue) {
-                $this->appendMessage($message, $field, 'ConfirmationOf');
                 $this->appendMessage($message, $fieldConfirmation, 'ConfirmationOf');
 
                 return false;


### PR DESCRIPTION
The confirmationOf validator class appends two messages to the model which means that when looping validation messages the confirmation failure is printed twice. This change means that message is only attached to the confirmation field seeing as this is the only field that has really failed validation.
