### PR TITLE
di reset method static access

### DIFF
--- a/Library/Phalcon/Test/UnitTestCase.php
+++ b/Library/Phalcon/Test/UnitTestCase.php
@@ -152,7 +152,8 @@ abstract class UnitTestCase extends \PHPUnit_Framework_TestCase
 
     protected function tearDown()
     {
-        $this->getDI()->reset();
+        $di = $this->getDI();
+        $di::reset();
         parent::tearDown();
     }
 }


### PR DESCRIPTION
Phalcon¥DiInterface  
line.113
public static function reset();

reset is static method;

modified to work in PHP >=5.4 without warnings.
