### PR TITLE
Session database adapter bug

### DIFF
--- a/Library/Phalcon/Session/Adapter/Database.php
+++ b/Library/Phalcon/Session/Adapter/Database.php
@@ -168,7 +168,7 @@ class Database extends Adapter implements AdapterInterface
         } else {
             return $options['db']->execute(
                 sprintf(
-                    'INSERT INTO %s (%s, %s, %s, %s) VALUES (?, ?, ?, 0)',
+                    'INSERT INTO %s (%s, %s, %s, %s) VALUES (?, ?, ?, NULL)',
                     $options['db']->escapeIdentifier($options['table']),
                     $options['db']->escapeIdentifier($options['column_session_id']),
                     $options['db']->escapeIdentifier($options['column_data']),


### PR DESCRIPTION
If `modified_at` value is '0' or NULL, actual session cannot be found.
