### PR TITLE
SQL INSERT "column_modified_at" now "time()".

### DIFF
--- a/Library/Phalcon/Session/Adapter/Database.php
+++ b/Library/Phalcon/Session/Adapter/Database.php
@@ -167,14 +167,14 @@ class Database extends Adapter implements AdapterInterface
         } else {
             return $options['db']->execute(
                 sprintf(
-                    'INSERT INTO %s (%s, %s, %s, %s) VALUES (?, ?, ?, 0)',
+                    'INSERT INTO %s (%s, %s, %s, %s) VALUES (?, ?, ?, ?)',
                     $options['db']->escapeIdentifier($options['table']),
                     $options['db']->escapeIdentifier($options['column_session_id']),
                     $options['db']->escapeIdentifier($options['column_data']),
                     $options['db']->escapeIdentifier($options['column_created_at']),
                     $options['db']->escapeIdentifier($options['column_modified_at'])
                 ),
-                array($sessionId, $data, time())
+                array($sessionId, $data, time(), time())
             );
         }
     }


### PR DESCRIPTION
Before the SQL INSERT statement set "column_modified_at" to 0. The result was that the SELECT in the read function did not get newly created sessions.
