### PR TITLE
Options in assets outputCss and outputJs Twig methods

### DIFF
--- a/Library/Phalcon/Mvc/View/Engine/Twig/CoreExtension.php
+++ b/Library/Phalcon/Mvc/View/Engine/Twig/CoreExtension.php
@@ -55,7 +55,7 @@ class CoreExtension extends \Twig_Extension
      * @param  string|null                               $options Assets CollectionName
      * @return string
      */
-    public function functionAssetsOutputCss(Environment $env, $options)
+    public function functionAssetsOutputCss(Environment $env, $options = null)
     {
         return $this->getAssetsOutput($env, 'outputCss', $options);
     }
@@ -67,7 +67,7 @@ class CoreExtension extends \Twig_Extension
      * @param  string|null                               $options Assets CollectionName
      * @return string
      */
-    public function functionAssetsOutputJs(Environment $env, $options)
+    public function functionAssetsOutputJs(Environment $env, $options = null)
     {
         return $this->getAssetsOutput($env, 'outputJs', $options);
     }


### PR DESCRIPTION
Allowing to acccept CollectionName parameter in outputCss and outputJs method. 

Phalcon docs:
public outputCss ([string $collectionName])
public outputJs ([string $collectionName])
http://docs.phalconphp.com/ru/latest/api/Phalcon_Assets_Manager.html
