### PR TITLE
Adding Decimal Validator

### DIFF
--- a/Library/Phalcon/Mvc/Model/Validator/Decimal.php
+++ b/Library/Phalcon/Mvc/Model/Validator/Decimal.php
@@ -1,0 +1,92 @@
+<?php
+namespace Phalcon\Mvc\Model\Validator;
+
+use Phalcon\Mvc\Model\Validator as ModelValidator,
+    Phalcon\Mvc\Model\ValidatorInterface,
+    Phalcon\Mvc\Model\Exception,
+    Phalcon\Mvc\ModelInterface;
+
+/**
+ * Phalcon\Mvc\Model\Validator\Decimal
+ *
+ * Validates that a value is a valid number in proper decimal format (negative and decimal numbers allowed).
+ * Optionally, a specific number of digits can be checked too.
+ *
+ * Uses {@link http://www.php.net/manual/en/function.localeconv.php locale conversion} to allow decimal point to be locale specific.
+ *
+ *<code>
+ *use Phalcon\Mvc\Model\Validator\Decimal;
+ *
+ *class Product extends Phalcon\Mvc\Model
+ *{
+ *
+ *	public function validation()
+ *	{
+ *		$this->validate(new Decimal(array(
+ *			'field' => 'price',
+ *			'places' => 2,
+ *			'digit' => 3, // optional
+ *			'message' => 'Price must contain valid decimal value',
+ *		)));
+ *
+ *		if ($this->validationHasFailed() == true) {
+ *			return false;
+ *		}
+ *	}
+ *
+ *}
+ *</code>
+ */
+class Decimal extends ModelValidator implements ValidatorInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @param $record
+     * @return boolean
+     * @throws Exception
+     */
+    public function validate(ModelInterface $record)
+    {
+        if (false === is_object($record) || false === $record instanceof ModelInterface) {
+            throw new Exception('Invalid parameter type.');
+        }
+
+        $field = $this->getOption('field');
+
+        if (false === is_string($field)) {
+            throw new Exception('Field name must be a string');
+        }
+
+        if (false === $this->isSetOption('places')) {
+            throw new Exception('A number of decimal places must be set');
+        }
+
+        $places = $this->getOption('places');
+
+        if ($this->isSetOption('digits')) {
+            // Specific number of digits
+            $digits = '{'.( (int) $this->getOption('digits')).'}';
+        } else {
+            // Any number of digits
+            $digits = '+';
+        }
+
+        // Get the decimal point for the current locale
+        list($decimal) = array_values(localeconv());
+
+        $value = $record->readAttribute($field);
+
+        $regexp = (bool) preg_match('#^[+-]?[0-9]'.$digits.preg_quote($decimal).'[0-9]{'.( (int) $places).'}$#', $value);
+
+        if (!$regexp) {
+            // Check if the developer has defined a custom message
+            $message = $this->getOption('message') ?: sprintf('%s must contain valid decimal value', $field);
+
+            $this->appendMessage($message, $field, 'Decimal');
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Library/Phalcon/Mvc/Model/Validator/Decimal.php
+++ b/Library/Phalcon/Mvc/Model/Validator/Decimal.php
@@ -1,10 +1,10 @@
 <?php
 namespace Phalcon\Mvc\Model\Validator;
 
-use Phalcon\Mvc\Model\Validator as ModelValidator,
-    Phalcon\Mvc\Model\ValidatorInterface,
-    Phalcon\Mvc\Model\Exception,
-    Phalcon\Mvc\ModelInterface;
+use Phalcon\Mvc\Model\Validator as ModelValidator;
+use Phalcon\Mvc\Model\ValidatorInterface;
+use Phalcon\Mvc\Model\Exception;
+use Phalcon\Mvc\ModelInterface;
 
 /**
  * Phalcon\Mvc\Model\Validator\Decimal

--- a/Library/Phalcon/Mvc/Model/Validator/Decimal.php
+++ b/Library/Phalcon/Mvc/Model/Validator/Decimal.php
@@ -59,6 +59,12 @@ class Decimal extends ModelValidator implements ValidatorInterface
             throw new Exception('Field name must be a string');
         }
 
+        $value = $record->readAttribute($field);
+
+        if (true === $this->isSetOption('allowEmpty') && empty($value)) {
+            return true;
+        }
+
         if (false === $this->isSetOption('places')) {
             throw new Exception('A number of decimal places must be set');
         }
@@ -79,8 +85,6 @@ class Decimal extends ModelValidator implements ValidatorInterface
             // Get the decimal point for the current locale
             list($decimal) = array_values(localeconv());
         }
-
-        $value = $record->readAttribute($field);
 
         $regexp = (bool) preg_match('#^[+-]?[0-9]'.$digits.preg_quote($decimal).'[0-9]{'.( (int) $places).'}$#', $value);
 

--- a/Library/Phalcon/Mvc/Model/Validator/Decimal.php
+++ b/Library/Phalcon/Mvc/Model/Validator/Decimal.php
@@ -20,19 +20,20 @@ use Phalcon\Mvc\Model\Validator as ModelValidator,
  *class Product extends Phalcon\Mvc\Model
  *{
  *
- *	public function validation()
- *	{
- *		$this->validate(new Decimal(array(
- *			'field' => 'price',
- *			'places' => 2,
- *			'digit' => 3, // optional
- *			'message' => 'Price must contain valid decimal value',
- *		)));
+ *  public function validation()
+ *  {
+ *      $this->validate(new Decimal(array(
+ *          'field' => 'price',
+ *          'places' => 2,
+ *          'digit' => 3, // optional
+ *          'point' => ',' // optional. uses to override system decimal point
+ *          'message' => 'Price must contain valid decimal value',
+ *      )));
  *
- *		if ($this->validationHasFailed() == true) {
- *			return false;
- *		}
- *	}
+ *      if ($this->validationHasFailed() == true) {
+ *          return false;
+ *      }
+ *  }
  *
  *}
  *</code>
@@ -72,8 +73,12 @@ class Decimal extends ModelValidator implements ValidatorInterface
             $digits = '+';
         }
 
-        // Get the decimal point for the current locale
-        list($decimal) = array_values(localeconv());
+        if ($this->isSetOption('point')) {
+            $decimal = $this->getOption('point');
+        } else {
+            // Get the decimal point for the current locale
+            list($decimal) = array_values(localeconv());
+        }
 
         $value = $record->readAttribute($field);
 

--- a/Library/Phalcon/Mvc/Model/Validator/Decimal.php
+++ b/Library/Phalcon/Mvc/Model/Validator/Decimal.php
@@ -12,7 +12,8 @@ use Phalcon\Mvc\ModelInterface;
  * Validates that a value is a valid number in proper decimal format (negative and decimal numbers allowed).
  * Optionally, a specific number of digits can be checked too.
  *
- * Uses {@link http://www.php.net/manual/en/function.localeconv.php locale conversion} to allow decimal point to be locale specific.
+ * Uses {@link http://www.php.net/manual/en/function.localeconv.php locale conversion} to allow decimal point to be
+ * locale specific.
  *
  *<code>
  *use Phalcon\Mvc\Model\Validator\Decimal;
@@ -86,7 +87,7 @@ class Decimal extends ModelValidator implements ValidatorInterface
             list($decimal) = array_values(localeconv());
         }
 
-        $regexp = (bool) preg_match('#^[+-]?[0-9]'.$digits.preg_quote($decimal).'[0-9]{'.( (int) $places).'}$#', $value);
+        $regexp = (bool) preg_match('#^[+-]?[0-9]'.$digits.preg_quote($decimal).'[0-9]{'.((int) $places).'}$#', $value);
 
         if (!$regexp) {
             // Check if the developer has defined a custom message

--- a/Library/Phalcon/Mvc/Model/Validator/README.md
+++ b/Library/Phalcon/Mvc/Model/Validator/README.md
@@ -39,3 +39,34 @@ class User extends Model
 }
 
 ```
+
+Decimal
+--------------
+Allows to validate if a field has a valid number in proper decimal format (negative and decimal numbers allowed).
+Optionally, a specific number of digits can be checked too. Uses [locale conversion](http://www.php.net/manual/en/function.localeconv.php) to allow decimal point to be locale specific.
+
+```php
+use Phalcon\Mvc\Model\Validator\Decimal;
+
+use Phalcon\Mvc\Model;
+
+class Product extends Model
+{
+
+     public function validation()
+     {
+         $this->validate(new Decimal(array(
+              'field' => 'price',
+              'places' => 2,
+              'digit' => 3, // optional
+              'message' => 'Price must contain valid decimal value',
+         )));
+
+         if ($this->validationHasFailed() == true) {
+              return false;
+         }
+     }
+
+}
+
+```

--- a/Library/Phalcon/Mvc/Model/Validator/README.md
+++ b/Library/Phalcon/Mvc/Model/Validator/README.md
@@ -59,6 +59,7 @@ class Product extends Model
               'field' => 'price',
               'places' => 2,
               'digit' => 3, // optional
+              'point' => ',' // optional. uses to override system decimal point
               'message' => 'Price must contain valid decimal value',
          )));
 


### PR DESCRIPTION
Allows to validate if a field has a valid number in proper decimal format (negative and decimal numbers allowed). Optionally, a specific number of digits can be checked too. Uses [locale conversion](http://www.php.net/manual/en/function.localeconv.php) to allow decimal point to be locale specific.

```php
use Phalcon\Mvc\Model\Validator\Decimal;

use Phalcon\Mvc\Model;

class Product extends Model
{

     public function validation()
     {
         $this->validate(new Decimal(array(
              'field' => 'price', // number to check
              'places' => 2,      // number of decimal places
              'digit' => 3,       // optional. number of digits
              'point' => ','      // optional. uses to override system decimal point
              'message' => 'Price must contain valid decimal value',
         )));

         if ($this->validationHasFailed() == true) {
              return false;
         }
     }

}

```