### PR TITLE
Add Library/Phalcon/Mvc/Model/Validator/CardNumber.php

### DIFF
--- a/Library/Phalcon/Mvc/Model/Validator/CardNumber.php
+++ b/Library/Phalcon/Mvc/Model/Validator/CardNumber.php
@@ -46,7 +46,7 @@ class CardNumber extends \Phalcon\Mvc\Model\Validator
 
         $fieldValue = $record->readAttribute($field);
 
-        $value = strrev(preg_replace('/[^\d]/','',$fieldValue));
+        $value = strrev(preg_replace('/[^\d]/', '', $fieldValue));
         $checkSum = 0;
 
         for ($i = 0; $i < strlen($value); $i++) {
@@ -55,14 +55,15 @@ class CardNumber extends \Phalcon\Mvc\Model\Validator
                 $temp = $value[$i];
             } else {
                 $vabufl = $value[$i] * 2;
-                if ($temp > 9)  $temp -= 9;
+                if ($temp > 9) {
+                    $temp -= 9;
+                }
             }
 
             $checkSum += $temp;
         }
 
-        if ( ($checkSum % 10) != 0)
-        {
+        if (($checkSum % 10) != 0) {
             $message = $this->getOption('message') ?: 'Credit card number is invalid';
 
             $this->appendMessage($message, $field, "CardNumber");

--- a/Library/Phalcon/Mvc/Model/Validator/CardNumber.php
+++ b/Library/Phalcon/Mvc/Model/Validator/CardNumber.php
@@ -1,0 +1,73 @@
+<?php
+namespace Phalcon\Mvc\Model\Validator;
+
+use Phalcon\Mvc\Model\Exception;
+use Phalcon\Mvc\ModelInterface;
+
+/**
+ * Phalcon\Mvc\Model\Validator\CardNumber
+ *
+ * Validates credit card number using Luhn algorithm
+ *
+ *<code>
+ *use Phalcon\Mvc\Model\Validator\CardNumber;
+ *
+ *class User extends Phalcon\Mvc\Model
+ *{
+ *
+ *  public function validation()
+ *  {
+ *      $this->validate(new CardNumber(array(
+ *          'field' => 'cardnumber',
+ *          'message' => 'Card number must be valid',
+ *      )));
+ *
+ *      if ($this->validationHasFailed() == true) {
+ *          return false;
+ *      }
+ *  }
+ *
+ *}
+ *</code>
+ */
+class CardNumber extends \Phalcon\Mvc\Model\Validator
+{
+    public function validate($record)
+    {
+        if (false === is_object($record) || false === $record instanceof ModelInterface) {
+            throw new Exception('Invalid parameter type.');
+        }
+
+        $field = $this->getOption('field');
+
+        if (false === is_string($field)) {
+            throw new Exception('Field name must be a string');
+        }
+
+        $fieldValue = $record->readAttribute($field);
+
+        $value = strrev(preg_replace('/[^\d]/','',$fieldValue));
+        $checkSum = 0;
+
+        for ($i = 0; $i < strlen($value); $i++) {
+
+            if (($i % 2) == 0) {
+                $temp = $value[$i];
+            } else {
+                $vabufl = $value[$i] * 2;
+                if ($temp > 9)  $temp -= 9;
+            }
+
+            $checkSum += $temp;
+        }
+
+        if ( ($checkSum % 10) != 0)
+        {
+            $message = $this->getOption('message') ?: 'Credit card number is invalid';
+
+            $this->appendMessage($message, $field, "CardNumber");
+            return false;
+        }
+        return true;
+    }
+}

--- a/Library/Phalcon/Mvc/Model/Validator/README.md
+++ b/Library/Phalcon/Mvc/Model/Validator/README.md
@@ -101,3 +101,29 @@ class Slider extends Model
 }
 
 ```
+
+CardNumber
+-------
+Validates credit card number using Luhn algorithm
+
+```php
+
+use Phalcon\Mvc\Model;
+use Phalcon\Mvc\Model\Validator\CardNumber;
+
+class User extends Phalcon\Mvc\Model
+{
+     public function validation()
+     {
+          $this->validate(new CardNumber(array(
+               'field' => 'cardnumber',
+               'message' => 'Card number must be valid',
+          )));
+ 
+          if ($this->validationHasFailed() == true) {
+               return false;
+          }
+      }
+}
+
+```

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ $loader->register();
 * [Phalcon\Mvc\View\Engine\Smarty](https://github.com/phalcon/incubator/tree/master/Library/Phalcon/Mvc/View/Engine) - Adapter for Smarty (phalcon)
 
 ### ORM Validators
-* [Phalcon\Mvc\Model\Validator\ConfirmationOf](https://github.com/phalcon/incubator/tree/master/Library/Phalcon/Mvc/Model) - Allows to validate if a field has a confirmation field with the same value (suxxes)
+* [Phalcon\Mvc\Model\Validator\ConfirmationOf](https://github.com/phalcon/incubator/tree/master/Library/Phalcon/Mvc/Model/Validator) - Allows to validate if a field has a confirmation field with the same value (suxxes)
+* [Phalcon\Mvc\Model\Validator\CardNumber](https://github.com/phalcon/incubator/tree/master/Library/Phalcon/Mvc/Model/Validator) - Allows to validate credit cadrd number using Luhn algorithm (parshikov)
 
 ### Error Handling
 * [Phalcon\Error](https://github.com/phalcon/incubator/tree/master/Library/Phalcon/Error) - Error handler used to centralize the error handling and displaying clean error pages (theDisco)


### PR DESCRIPTION
Allows to validate creditcard number using Luhn algorithm
```php
use Phalcon\Mvc\Model;
use Phalcon\Mvc\Model\Validator\CardNumber;

class User extends Phalcon\Mvc\Model
{
     public function validation()
     {
          $this->validate(new CardNumber(array(
               'field' => 'cardnumber',
               'message' => 'Card number must be valid',
          )));
 
          if ($this->validationHasFailed() == true) {
               return false;
          }
      }
}
```