### PR TITLE
Twig extension to allow user defined functions

### DIFF
--- a/Library/Phalcon/Mvc/View/Engine/README.md
+++ b/Library/Phalcon/Mvc/View/Engine/README.md
@@ -86,6 +86,35 @@ $di->set('view', function() {
 });
 ```
 
+You can also create your own defined functions to extend Twig parsing capabilities by passing a forth parameter to the Twig constructor that consists of an Array of Twig_SimpleFunction elements. This will allow you to extend Twig, or even override default functions, with your own.
+
+```php
+//Setting up the view component
+$di->set('view', function() {
+
+    $view = new \Phalcon\Mvc\View();
+
+    $view->setViewsDir('../app/views/');
+
+    $view->registerEngines(
+        array(
+            '.twig' => function($view, $di) {
+                //Setting up Twig Environment Options
+                $options = array('cache' => '../cache/');
+                // Adding support for the native PHP chunk_split function
+                $user_functions = array(
+		            new \Twig_SimpleFunction('chunk_split', function ($string, $len = 76, $end = "\r\n") use ($di) {
+		                return chunk_split($string, $len, $end);
+		            }, $options)
+		        );
+                $twig = new \Phalcon\Mvc\View\Engine\Twig($view, $di, $options, $user_functions);
+                return $twig;
+            }));
+
+    return $view;
+});
+```
+
 The engine implements "assets" tag in Twig templates:
 
 ```django

--- a/Library/Phalcon/Mvc/View/Engine/Twig.php
+++ b/Library/Phalcon/Mvc/View/Engine/Twig.php
@@ -23,13 +23,13 @@ class Twig extends Engine implements EngineInterface
      * @param \Phalcon\DiInterface       $di
      * @param array                      $options
      */
-    public function __construct($view, $di = null, $options = array())
+    public function __construct($view, $di = null, $options = array(), $user_functions = array())
     {
         $loader     = new \Twig_Loader_Filesystem($view->getViewsDir());
         $this->twig = new Twig\Environment($di, $loader, $options);
 
         $this->twig->addExtension(new Twig\CoreExtension());
-        $this->registryFunctions($view, $di);
+        $this->registryFunctions($view, $di, $user_functions);
 
         parent::__construct($view, $di);
     }
@@ -39,7 +39,7 @@ class Twig extends Engine implements EngineInterface
      *
      * @param \Phalcon\Mvc\ViewInterface $view
      */
-    protected function registryFunctions($view, $di)
+    protected function registryFunctions($view, $di, $user_functions)
     {
         $options = array(
             'is_safe' => array('html')
@@ -119,7 +119,9 @@ class Twig extends Engine implements EngineInterface
                 return $di->get("url")->get($route);
             }, $options)
         );
-
+    
+        $functions = array_merge($functions, $user_functions);
+        
         foreach ($functions as $function) {
             $this->twig->addFunction($function);
         }


### PR DESCRIPTION
Hi guys, I just added the option to extend Twig parsing capabilities without having to modify the Twig.php file itself. 

I needed to add a native PHP function to the template parser but modifying the Twig.php file by hand isn't a good option at all, specially if I were to get an updated version and lose everything I did. 

So I decided to extend it so you guys can also benefit, maybe, from this change. I also updated the README to reflect the changes.

Hope it helps!