### PR TITLE
Delete method fixed in Redis Cache when used \Redis::OPT_PREFIX

### DIFF
--- a/Library/Phalcon/Cache/Backend/Redis.php
+++ b/Library/Phalcon/Cache/Backend/Redis.php
@@ -128,8 +128,19 @@ class Redis extends Prefixable
     public function delete($keyName)
     {
         $options = $this->getOptions();
+        $redisPrefix = $options['redis']->getOption(\Redis::OPT_PREFIX);
 
-        return $options['redis']->delete($this->getPrefixedIdentifier($keyName)) > 0;
+        if (!empty($redisPrefix)) {
+            $redisPrefixLen = strlen($redisPrefix);
+            $keys = $options['redis']->getKeys($this->getPrefixedIdentifier($keyName) . '*');
+            $keys = array_map(function ($key) use ($redisPrefixLen) {
+                return substr($key, $redisPrefixLen);
+            }, $keys);
+
+            return $options['redis']->delete($keys) > 0;
+        } else {
+            return $options['redis']->delete($this->getPrefixedIdentifier($keyName)) > 0;
+        }
     }
 
     /**


### PR DESCRIPTION
This changes asssigned with https://github.com/phalcon/incubator/pull/217