### PR TITLE
modified_at is NULL, session data doesn't delete endlessly.

### DIFF
--- a/Library/Phalcon/Session/Adapter/Database.php
+++ b/Library/Phalcon/Session/Adapter/Database.php
@@ -224,9 +224,10 @@ class Database extends Adapter implements AdapterInterface
 
         return $options['db']->execute(
             sprintf(
-                'DELETE FROM %s WHERE %s + %d < ?',
+                'DELETE FROM %s WHERE COALESCE(%s, %s) + %d < ?',
                 $options['db']->escapeIdentifier($options['table']),
                 $options['db']->escapeIdentifier($options['column_modified_at']),
+                $options['db']->escapeIdentifier($options['column_created_at']),
                 $maxlifetime
             ),
             array(time())


### PR DESCRIPTION
- first access  
modified_at is NULL.
- after second access  
modified_at is time().
- execution query by GC  
``DELETE FROM session WHERE modified_at + $maxlifetime < time()``

session data by first access only (NULL), not deleted.