### PR TITLE
Twig view engine Phalcon 2.0 compatibility

### DIFF
--- a/Library/Phalcon/Mvc/View/Engine/Twig.php
+++ b/Library/Phalcon/Mvc/View/Engine/Twig.php
@@ -24,7 +24,7 @@ class Twig extends Engine implements EngineInterface
      * @param array                      $options
      * @param array                      $userFunctions
      */
-    public function __construct($view, $di = null, $options = array(), $userFunctions = array())
+    public function __construct($view, \Phalcon\DiInterface $di = null, $options = array(), $userFunctions = array())
     {
         $loader     = new \Twig_Loader_Filesystem($view->getViewsDir());
         $this->twig = new Twig\Environment($di, $loader, $options);


### PR DESCRIPTION
The Twig constructor was not type hinting DiInterface, this was making unhappy times when using Phalcon 2.0