### PR TITLE
Twig - rendering engine makes Phalcon 2.0 unhappy

### DIFF
--- a/Library/Phalcon/Mvc/View/Engine/Twig.php
+++ b/Library/Phalcon/Mvc/View/Engine/Twig.php
@@ -24,7 +24,7 @@ class Twig extends Engine implements EngineInterface
      * @param array                      $options
      * @param array                      $userFunctions
      */
-    public function __construct($view, $di = null, $options = array(), $userFunctions = array())
+    public function __construct($view, \Phalcon\DiInterface $di = null, $options = array(), $userFunctions = array())
     {
         $loader     = new \Twig_Loader_Filesystem($view->getViewsDir());
         $this->twig = new Twig\Environment($di, $loader, $options);
@@ -42,7 +42,7 @@ class Twig extends Engine implements EngineInterface
      * @param \Phalcon\DiInterface       $di
      * @param array                      $userFunctions
      */
-    protected function registryFunctions($view, $di, $userFunctions = array())
+    protected function registryFunctions($view, \Phalcon\DiInterface $di, $userFunctions = array())
     {
         $options = array(
             'is_safe' => array('html')


### PR DESCRIPTION
The Twig constructor was not type hinting DiInterface, this was making unhappy times when using Phalcon 2.0