### PR TITLE
Twig view engine Phalcon 2.0 compatibility

### DIFF
--- a/Library/Phalcon/Mvc/View/Engine/Twig.php
+++ b/Library/Phalcon/Mvc/View/Engine/Twig.php
@@ -3,6 +3,7 @@ namespace Phalcon\Mvc\View\Engine;
 
 use Phalcon\Mvc\View\Engine;
 use Phalcon\Mvc\View\EngineInterface;
+use Phalcon\DiInterface;
 
 /**
  * Phalcon\Mvc\View\Engine\Twig
@@ -24,7 +25,7 @@ class Twig extends Engine implements EngineInterface
      * @param array                      $options
      * @param array                      $userFunctions
      */
-    public function __construct($view, $di = null, $options = array(), $userFunctions = array())
+    public function __construct($view, DiInterface $di = null, $options = array(), $userFunctions = array())
     {
         $loader     = new \Twig_Loader_Filesystem($view->getViewsDir());
         $this->twig = new Twig\Environment($di, $loader, $options);
@@ -42,7 +43,7 @@ class Twig extends Engine implements EngineInterface
      * @param \Phalcon\DiInterface       $di
      * @param array                      $userFunctions
      */
-    protected function registryFunctions($view, $di, $userFunctions = array())
+    protected function registryFunctions($view, DiInterface $di, $userFunctions = array())
     {
         $options = array(
             'is_safe' => array('html')


### PR DESCRIPTION
The Twig engine class constructor and a method was not hinting the DI interface class, which was not pleasing the Phalcon module as of 2.0.

_Disregard the fact I've made multiple pull requests on the same issue. Mild case of PEBKAC here._