### PR TITLE
Database session adapter methods overriding start method to prevent session_register()

### DIFF
--- a/Library/Phalcon/Session/Adapter/Database.php
+++ b/Library/Phalcon/Session/Adapter/Database.php
@@ -32,6 +32,13 @@ class Database extends Adapter implements AdapterInterface
 {
 
     /**
+     * Flag to check if session has been started.
+     *
+     * @var boolean
+     */
+    protected $isStarted = false;
+
+    /**
      * Flag to check if session is destroyed.
      *
      * @var boolean
@@ -81,6 +88,27 @@ class Database extends Adapter implements AdapterInterface
             array($this, 'destroy'),
             array($this, 'gc')
         );
+
+        $this->start();
+    }
+
+    /**
+     * {@inheritdoc}
+     * @return boolean
+     */
+    public function isStarted()
+    {
+        return $this->isStarted;
+    }
+
+    /**
+     * {@inheritdoc}
+     * @return boolean
+     */
+    public function start()
+    {
+        $this->isStarted = true;
+        return true;
     }
 
     /**


### PR DESCRIPTION
Session database adapter should have the start and isStarted methods overridden, otherwise the start method will register a PHP session which will not/should not be used.

Otherwise using code like

```php
if (!$session->isStarted())
    $session->start();
```

will result in a call to session_register()