### PR TITLE
reverting e3b1083 in case of issue #318

### DIFF
--- a/Library/Phalcon/Session/Adapter/Database.php
+++ b/Library/Phalcon/Session/Adapter/Database.php
@@ -32,13 +32,6 @@ class Database extends Adapter implements AdapterInterface
 {
 
     /**
-     * Flag to check if session has been started.
-     *
-     * @var boolean
-     */
-    protected $isStarted = false;
-
-    /**
      * Flag to check if session is destroyed.
      *
      * @var boolean
@@ -88,27 +81,6 @@ class Database extends Adapter implements AdapterInterface
             array($this, 'destroy'),
             array($this, 'gc')
         );
-
-        $this->start();
-    }
-
-    /**
-     * {@inheritdoc}
-     * @return boolean
-     */
-    public function isStarted()
-    {
-        return $this->isStarted;
-    }
-
-    /**
-     * {@inheritdoc}
-     * @return boolean
-     */
-    public function start()
-    {
-        $this->isStarted = true;
-        return true;
     }
 
     /**


### PR DESCRIPTION
reverting e3b10837444f166fc56e1c7e1685f35ecb72ad45 because it makes Sessions\Adapter\Database to not work in way it's described in readme.