### PR TITLE
Twig __construct compatible with phalcon 2.0.1

### DIFF
--- a/Library/Phalcon/Mvc/View/Engine/Twig.php
+++ b/Library/Phalcon/Mvc/View/Engine/Twig.php
@@ -3,6 +3,7 @@ namespace Phalcon\Mvc\View\Engine;
 
 use Phalcon\Mvc\View\Engine;
 use Phalcon\Mvc\View\EngineInterface;
+use Phalcon\Mvc\ViewBaseInterface;
 use Phalcon\DiInterface;
 
 /**
@@ -25,7 +26,7 @@ class Twig extends Engine implements EngineInterface
      * @param array                      $options
      * @param array                      $userFunctions
      */
-    public function __construct($view, DiInterface $di = null, $options = array(), $userFunctions = array())
+    public function __construct(ViewBaseInterface $view, DiInterface $di = null, $options = array(), $userFunctions = array())
     {
         $loader     = new \Twig_Loader_Filesystem($view->getViewsDir());
         $this->twig = new Twig\Environment($di, $loader, $options);


### PR DESCRIPTION
Fatal error: Declaration of Phalcon\Mvc\View\Engine\Twig::__construct() must be compatible with Phalcon\Mvc\View\EngineInterface::__construct(Phalcon\Mvc\ViewBaseInterface $view, Phalcon\DiInterface $dependencyInjector = NULL) in ./vendor/phalcon/incubator/Library/Phalcon/Mvc/View/Engine/Twig.php on line 13