### PR TITLE
Phalcon\Mvc\Model\MetaData\Base now implments MetaDataInterface

### DIFF
--- a/Library/Phalcon/Mvc/Model/MetaData/Base.php
+++ b/Library/Phalcon/Mvc/Model/MetaData/Base.php
@@ -29,7 +29,7 @@ use Phalcon\Mvc\Model\MetaData;
  * @license  New BSD License
  * @link     http://phalconphp.com/
  */
-abstract class Base extends MetaData
+abstract class Base extends MetaData implements \Phalcon\Mvc\Model\MetaDataInterface
 {
     /**
      * Default options for cache backend.

--- a/tests/Phalcon/Mvc/Model/MetaData/BaseTest.php
+++ b/tests/Phalcon/Mvc/Model/MetaData/BaseTest.php
@@ -1,0 +1,32 @@
+<?php
+namespace Phalcon\Test\Mvc\Model\MetaData;
+
+class BaseTest extends \PHPUnit_Framework_TestCase
+{
+    public function testBaseMetaDataObjectImplementsMetaDataInterface()
+    {
+        $stub = new \Phalcon\Test\Mvc\Model\MetaData\BaseMetaDataStub();
+        $this->assertInstanceOf('Phalcon\Mvc\Model\MetaDataInterface', $stub);
+    }
+
+    public function testRedisMetaDataAdapterImplementsMetaDataInterface()
+    {
+        $redisMock = $this->getMockBuilder('Phalcon\Mvc\Model\MetaData\Redis')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->assertInstanceOf('Phalcon\Mvc\Model\MetaDataInterface', $redisMock);
+    }
+}
+
+class BaseMetaDataStub extends \Phalcon\Mvc\Model\MetaData\Base
+{
+    /**
+     * Returns cache backend instance.
+     *
+     * @return \Phalcon\Cache\BackendInterface
+     */
+    protected function getCacheBackend()
+    {
+        return new \Phalcon\Cache\Backend\Memory();
+    }
+}


### PR DESCRIPTION
Phalcon\Mvc\Model\MetaData\Redis (and probably other adapters too) was throwing exception on \Phalcon\Mvc\Model::_doLowInsert(
        \Phalcon\Mvc\Model\MetaDataInterface $metaData,
        \Phalcon\Db\AdapterInterface $connection,
        $table,
        $identityField
)
because of not implementing MetaDataInterface