### PR TITLE
Non-alphanumeric character fix and improved $replace usage

### DIFF
--- a/Library/Phalcon/Utils/Slug.php
+++ b/Library/Phalcon/Utils/Slug.php
@@ -17,6 +17,7 @@
   +------------------------------------------------------------------------+
   | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
   |          Nikolaos Dimopoulos <nikos@niden.net>                         |
+  |          Ilgıt Yıldırım <ilgityildirim@gmail.com>                      |
   +------------------------------------------------------------------------+
 */
 namespace Phalcon\Utils;
@@ -43,11 +44,19 @@ class Slug
         $oldLocale = setlocale(LC_ALL, '0');
         setlocale(LC_ALL, 'en_US.UTF-8');
 
-        $clean = iconv('UTF-8', 'ASCII//TRANSLIT', $string);
+        // replace non letter or non digits by -
+        $string = preg_replace("#[^\\pL\d]+#u", '-', $string);
 
-        if (!empty($replace)) {
-            $clean = str_replace((array) $replace, ' ', $clean);
+        // Trim trailing -
+        $string = trim($string,'-');
+
+        // Better to replace given $replace array as index => value
+        // Example $replace('ı' => 'i', 'İ' => 'i');
+        if (!empty($replace) && is_array($replace)) {
+            $string = str_replace(array_keys($replace), array_values($replace), $string);
         }
+
+        $clean = iconv('UTF-8', 'ASCII//TRANSLIT', $string);
 
         $clean = preg_replace("/[^a-zA-Z0-9\/_|+ -]/", '', $clean);
         $clean = strtolower($clean);


### PR DESCRIPTION
There was a problem with non-alphanumeric characters as it was turning them into their ASCII counterparts.
**Example String** ````Phalcon's incubator is great````
**Output** ````phalcon39s-incubator-is-great````

Obviously this is not the expected nor wanted output.
**New Output** ````phalcon-s-incubator-is-great````

````$replace```` was also just replacing any given character with a space ```` ```` This might not be the case in some situations such as;
**Example String** ````What does it mean yapılır in Turkish````
**Output** ````what-does-it-mean-yaplr-in-turkish````

We can simply pass ```$replace = [ 'ı' => 'i' ]``` with the new update to overcome this problem
**New Output** ````what-does-it-mean-yapilir-in-turkish````