### PR TITLE
fix Gettext::setDomain fails when called with NULL as argument (defau…

### DIFF
--- a/Library/Phalcon/Translate/Adapter/Gettext.php
+++ b/Library/Phalcon/Translate/Adapter/Gettext.php
@@ -161,6 +161,7 @@ class Gettext extends Base implements AdapterInterface
      * @param  array $placeholders Optional.
      * @param  string $category    Optional. Specify the locale category.
      *                             Defaults to LC_MESSAGES
+     * @param  string $domain
      *
      * @return string
      * @throws \InvalidArgumentException
@@ -332,7 +333,7 @@ class Gettext extends Base implements AdapterInterface
      */
     public function setDomain($domain)
     {
-        if (!in_array($domain, $this->domains)) {
+        if ($domain !== NULL && !in_array($domain, $this->domains)) {
             throw new \InvalidArgumentException($domain . ' is invalid translation domain');
         }
 


### PR DESCRIPTION
The setDomain() method of Phalcon\Translate\Adapter\Gettext can get NULL as its first argument (called from Gettext::cquery or Gettext::cnquery). It failed with InvalidArgumentException. Passing NULL to setDomain is legitimate. It occurs when cquery() is called without the $domain argument (it defaults to NULL).