### PR TITLE
fix Gettext::setDomain fails when called with NULL as argument

### DIFF
--- a/Library/Phalcon/Db/Dialect/MysqlExtended.php
+++ b/Library/Phalcon/Db/Dialect/MysqlExtended.php
@@ -40,15 +40,12 @@ class MysqlExtended extends \Phalcon\Db\Dialect\Mysql
     {
         if ($expression["type"] == 'functionCall') {
             switch ($expression["name"]) {
-
                 case 'DATE_INTERVAL':
-
                     if (count($expression["arguments"]) != 2) {
                         throw new \Exception('DATE_INTERVAL requires 2 parameters');
                     }
 
                     switch ($expression["arguments"][1]['value']) {
-
                         case "'DAY'":
                             return 'INTERVAL ' . $this->getSqlExpression($expression["arguments"][0]) . ' DAY';
 
@@ -61,7 +58,6 @@ class MysqlExtended extends \Phalcon\Db\Dialect\Mysql
                     break;
 
                 case 'FULLTEXT_MATCH':
-
                     if (count($expression["arguments"]) < 2) {
                         throw new \Exception('FULLTEXT_MATCH requires 2 parameters');
                     }
@@ -76,7 +72,6 @@ class MysqlExtended extends \Phalcon\Db\Dialect\Mysql
                     $this->getSqlExpression($expression["arguments"][$length]) . ')';
 
                 case 'FULLTEXT_MATCH_BMODE':
-
                     if (count($expression["arguments"]) < 2) {
                         throw new \Exception('FULLTEXT_MATCH requires 2 parameters');
                     }

--- a/Library/Phalcon/Translate/Adapter/Gettext.php
+++ b/Library/Phalcon/Translate/Adapter/Gettext.php
@@ -161,6 +161,7 @@ class Gettext extends Base implements AdapterInterface
      * @param  array $placeholders Optional.
      * @param  string $category    Optional. Specify the locale category.
      *                             Defaults to LC_MESSAGES
+     * @param  string $domain
      *
      * @return string
      * @throws \InvalidArgumentException
@@ -332,7 +333,7 @@ class Gettext extends Base implements AdapterInterface
      */
     public function setDomain($domain)
     {
-        if (!in_array($domain, $this->domains)) {
+        if ($domain !== NULL && !in_array($domain, $this->domains)) {
             throw new \InvalidArgumentException($domain . ' is invalid translation domain');
         }
 

--- a/Library/Phalcon/Translate/Adapter/Gettext.php
+++ b/Library/Phalcon/Translate/Adapter/Gettext.php
@@ -333,7 +333,7 @@ class Gettext extends Base implements AdapterInterface
      */
     public function setDomain($domain)
     {
-        if ($domain !== NULL && !in_array($domain, $this->domains)) {
+        if ($domain !== null && !in_array($domain, $this->domains)) {
             throw new \InvalidArgumentException($domain . ' is invalid translation domain');
         }
 


### PR DESCRIPTION
The setDomain() method of Phalcon\Translate\Adapter\Gettext can get NULL as its first argument (called from Gettext::cquery or Gettext::cnquery). It failed with InvalidArgumentException. Passing NULL to setDomain is legitimate. It occurs when cquery() is called without the $domain argument (it defaults to NULL).