### PR TITLE
Removes the Redis cache backend which is no longer in the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ See CONTRIBUTING.md
 
 ### Cache
 * [Phalcon\Cache\Backend\Database](https://github.com/phalcon/incubator/tree/master/Library/Phalcon/Cache/Backend) - Database backend for caching data (phalcon)
-* [Phalcon\Cache\Backend\Redis](https://github.com/phalcon/incubator/tree/master/Library/Phalcon/Cache/Backend) - Redis backend for caching data (kenjikobe)
 * [Phalcon\Cache\Backend\Wincache](https://github.com/phalcon/incubator/tree/master/Library/Phalcon/Cache/Backend) - Wincache backend for caching data (nazwa)
 
 ### Config


### PR DESCRIPTION
This has been implemented in the core (https://github.com/phalcon/cphalcon/blob/master/phalcon/cache/backend/redis.zep) and is no longer part of this repo.