### PR TITLE
No need to use array here

### DIFF
--- a/Library/Phalcon/Mailer/Manager.php
+++ b/Library/Phalcon/Mailer/Manager.php
@@ -80,7 +80,7 @@ class Manager extends Component
         }
 
         if ($eventsManager) {
-            $eventsManager->fire('mailer:afterCreateMessage', $this, [$message]);
+            $eventsManager->fire('mailer:afterCreateMessage', $this, $message);
         }
 
         return $message;


### PR DESCRIPTION
The name of the event is `afterCreateMessage` not messages.
In a handler for this event we expect exactly one message not array of messages or something more.
I can't see why should be it passed in array?