### PR TITLE
Robuster parsing of taskFile for CLI Console.

### DIFF
--- a/Library/Phalcon/Cli/Console/Extended.php
+++ b/Library/Phalcon/Cli/Console/Extended.php
@@ -93,9 +93,9 @@ class Extended extends ConsoleApp
         }
 
         foreach ($scannedTasksDir as $taskFile) {
-            $taskClass = ($namespace ? $namespace . '\\' : '') . str_replace('.php', '', $taskFile);
-            $taskName  = strtolower(str_replace('Task', '', $taskClass));
-            $taskName  = trim($taskName, '\\');
+            $taskFileInfo = pathinfo($taskFile);
+            $taskClass = ($namespace ? $namespace . '\\' : '') . $taskFileInfo["filename"];
+            $taskName  = strtolower(str_replace('Task', '', $taskFileInfo["filename"]));
 
             $this->documentation[$taskName] = array('description'=>array(''), 'actions'=>array());
 


### PR DESCRIPTION
Hi,

When using `Phalcon\Cli\Console\Extended` in combination with namespaced task classes, the command `php app/cli.php taskname --help` shows no descriptions, even if they do exist. Removing the namespacing fixes the issue, but this is not a ideal solution for me.

I have located the problem and propose a fix.

As an example, consider a task with the name `App\Tasks\ConfigTask` that resides in `app/tasks/ConfigTask.php`. Before this fix, `$taskName` is parsed as `tasks/s/config` and no descriptions appear. With the patch it is parsed as `config` and the descriptions appear. I believe the `trim()` method does not work as expected, or not in all situations.

I have verified this fix in a non-namespaced situation too.