### PR TITLE
Inroduced Phalcon\Loader\Extended

### DIFF
--- a/Library/Phalcon/Loader/Extended.php
+++ b/Library/Phalcon/Loader/Extended.php
@@ -1,0 +1,316 @@
+<?php
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Framework                                                      |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2015 Phalcon Team (http://www.phalconphp.com)       |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file docs/LICENSE.txt.                        |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Serghei Iakovlev <serghei@phalconphp.com>                     |
+  +------------------------------------------------------------------------+
+*/
+
+namespace Phalcon\Loader;
+
+use Phalcon\Loader;
+
+/**
+ * Phalcon\Loader\Extended
+ *
+ * This component extends Phalcon\Loader and added ability to
+ * set multiple directories per namespace.
+ *
+ * <code>
+ * use Phalcon\Loader\Extended as Loader;
+ *
+ * // Creates the autoloader
+ * $loader = new Loader();
+ *
+ * // Register some namespaces
+ * $loader->registerNamespaces(
+ *     [
+ *         'Example\Base' => 'vendor/example/base/',
+ *         'Some\Adapters' => [
+ *             'vendor/example/adapters/src/',
+ *             'vendor/example/adapters/test/',
+ *         ]
+ *     ]
+ * );
+ *
+ * // Register autoloader
+ * $loader->register();
+ *
+ * // Requiring this class will automatically include file vendor/example/adapters/src/Some.php
+ * $adapter = Example\Adapters\Some();
+ *
+ * // Requiring this class will automatically include file vendor/example/adapters/test/Another.php
+ * $adapter = Example\Adapters\Another();
+ * </code>
+ *
+ * @package Phalcon\Loader
+ */
+class Extended extends Loader
+{
+    /**
+     * Register namespaces and their related directories
+     *
+     * @param array $namespaces
+     * @param bool $merge
+     * @return $this
+     */
+    public function registerNamespaces(array $namespaces, $merge = false)
+    {
+        $preparedNamespaces = $this->prepareNamespace($namespaces);
+
+        if ($merge) {
+            $currentNamespaces = $this->_namespaces;
+            if (is_array($currentNamespaces)) {
+                foreach ($preparedNamespaces as $name => $paths) {
+                    if (!isset($currentNamespaces[$name])) {
+                        $currentNamespaces[$name] = [];
+                    }
+
+                    $currentNamespaces[$name] = array_merge($currentNamespaces[$name], $paths);
+                }
+
+                $this->_namespaces = $currentNamespaces;
+            } else {
+                $this->_namespaces = $preparedNamespaces;
+            }
+        } else {
+            $this->_namespaces = $preparedNamespaces;
+        }
+
+        return $this;
+    }
+
+    protected function prepareNamespace(array $namespace)
+    {
+        $prepared = [];
+        foreach ($namespace as $name => $path) {
+            if (!is_array($path)) {
+                $path = [$path];
+            }
+
+            $prepared[$name] = $path;
+        }
+
+        return $prepared;
+    }
+
+    /**
+     * Autoloads the registered classes
+     *
+     * @param string $className
+     * @return bool
+     */
+    public function autoLoad($className)
+    {
+        if (!is_string($className) || empty($className)) {
+            return false;
+        }
+
+        if (is_object($this->_eventsManager)) {
+            $this->_eventsManager->fire('loader:beforeCheckClass', $this, $className);
+        }
+
+        /**
+         * First we check for static paths for classes
+         */
+        if (is_array($this->_classes) && isset($this->_classes[$className])) {
+            $filePath = $this->_classes[$className];
+
+            if (is_file($filePath)) {
+                if (is_object($this->_eventsManager)) {
+                    $this->_foundPath = $filePath;
+                    $this->_eventsManager->fire('loader:pathFound', $this, $filePath);
+                }
+
+                require $filePath;
+                return true;
+            }
+        }
+
+        $ds = DIRECTORY_SEPARATOR;
+        $ns = "\\";
+
+        /**
+         * Checking in namespaces
+         */
+        if (is_array($this->_namespaces)) {
+            foreach ($this->_namespaces as $nsPrefix => $directories) {
+                /**
+                 * The class name must start with the current namespace
+                 */
+                if (0 === strpos($className, $nsPrefix)) {
+                    $fileName = substr($className, strlen($nsPrefix . $ns));
+                    $fileName = str_replace($ns, $ds, $fileName);
+
+                    if ($fileName) {
+                        foreach ($directories as $directory) {
+                            /**
+                             * Add a trailing directory separator if the user forgot to do that
+                             */
+                            $fixedDirectory = rtrim($directory, $ds) . $ds;
+
+                            foreach ($this->_extensions as $extension) {
+                                $filePath = $fixedDirectory . $fileName . "." . $extension;
+
+                                /**
+                                 * Check if a events manager is available
+                                 */
+                                if (is_object($this->_eventsManager)) {
+                                    $this->_checkedPath = $filePath;
+                                    $this->_eventsManager->fire('loader:beforeCheckPath', $this);
+                                }
+
+                                /**
+                                 * This is probably a good path, let's check if the file exists
+                                 */
+                                if (is_file($filePath)) {
+                                    if (is_object($this->_eventsManager)) {
+                                        $this->_foundPath = $filePath;
+                                        $this->_eventsManager->fire('loader:pathFound', $this, $filePath);
+                                    }
+
+                                    /**
+                                     * Simulate a require
+                                     */
+                                    require $filePath;
+
+                                    /**
+                                     * Return true mean success
+                                     */
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /**
+         * Checking in prefixes
+         */
+        if (is_array($this->_prefixes)) {
+            foreach ($this->_prefixes as $prefix => $directory) {
+                /**
+                 * The class name starts with the prefix?
+                 */
+                if (0 === strpos($className, $prefix)) {
+                        /**
+                     * Get the possible file path
+                     */
+                    $fileName = str_replace($prefix . $ns, "", $className);
+                    $fileName = str_replace($prefix . "_", "", $fileName);
+                    $fileName = str_replace("_", $ds, $fileName);
+
+                    if ($fileName) {
+                        /**
+                         * Add a trailing directory separator if the user forgot to do that
+                         */
+                        $fixedDirectory = rtrim($directory, $ds) . $ds;
+
+                        foreach ($this->_extensions as $extension) {
+                            $filePath = $fixedDirectory . $fileName . "." . $extension;
+
+                            if (is_object($this->_eventsManager)) {
+                                $this->_checkedPath = $filePath;
+                                $this->_eventsManager->fire('loader:beforeCheckPath', $this, $filePath);
+                            }
+
+                            if (is_file($filePath)) {
+                                /**
+                                 * Call 'pathFound' event
+                                 */
+                                if (is_object($this->_eventsManager)) {
+                                    $this->_foundPath = $filePath;
+                                    $this->_eventsManager->fire('loader:pathFound', $this, $filePath);
+                                }
+
+                                require $filePath;
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /**
+         * Change the pseudo-separator by the directory separator in the class name
+         */
+        $dsClassName = str_replace("_", $ds, $className);
+
+        /**
+         * And change the namespace separator by directory separator too
+         */
+        $nsClassName = str_replace("\\", $ds, $dsClassName);
+
+        /**
+         * Checking in directories
+         */
+        if (is_array($this->_directories)) {
+            foreach ($this->_directories as $directory) {
+                /**
+                 * Add a trailing directory separator if the user forgot to do that
+                 */
+                $fixedDirectory = rtrim($directory, $ds) . $ds;
+
+                foreach ($this->_extensions as $extension) {
+                    /**
+                     * Create a possible path for the file
+                     */
+                    $filePath = $fixedDirectory . $nsClassName . "." . $extension;
+
+                    if (is_object($this->_eventsManager)) {
+                        $this->_checkedPath = $filePath;
+                        $this->_eventsManager->fire('loader:beforeCheckPath', $this, $filePath);
+                    }
+
+                    /**
+                     * Check in every directory if the class exists here
+                     */
+                    if (is_file($filePath)) {
+                        /**
+                         * Call 'pathFound' event
+                         */
+                        if (is_object($this->_eventsManager)) {
+                            $this->_foundPath = $filePath;
+                            $this->_eventsManager->fire('loader:pathFound', $this, $filePath);
+                        }
+
+                        /**
+                         * Simulate a require
+                         */
+                        require $filePath;
+
+                        /**
+                         * Return true meaning success
+                         */
+                        return true;
+                    }
+                }
+            }
+        }
+
+        /**
+         * Call 'afterCheckClass' event
+         */
+        if (is_object($this->_eventsManager)) {
+            $this->_eventsManager->fire('loader:afterCheckClass', $this, $className);
+        }
+
+        /**
+         * Cannot find the class, return false
+         */
+        return false;
+    }
+}

--- a/Library/Phalcon/Loader/README.md
+++ b/Library/Phalcon/Loader/README.md
@@ -1,0 +1,42 @@
+# Phalcon\Loader
+
+## Phalcon\Loader\Extended
+
+This component extends [Phalcon\Loader][1] and added ability to
+set multiple directories per namespace.
+
+```php
+use Phalcon\Loader\Extended as Loader;
+
+// Creates the autoloader
+$loader = new Loader();
+
+// Register some namespaces
+$loader->registerNamespaces(
+    [
+        'Example\Base' => 'vendor/example/base/',
+        'Some\Adapters' => [
+            'vendor/example/adapters/src/',
+            'vendor/example/adapters/test/',
+        ]
+    ]
+);
+
+// Register autoloader
+$loader->register();
+
+// Requiring this class will automatically include
+// file vendor/example/adapters/src/Some.php
+$adapter = Example\Adapters\Some();
+
+// Requiring this class will automatically include
+// file vendor/example/adapters/test/Another.php
+$adapter = Example\Adapters\Another();
+```
+
+## Phalcon\Loader\PSR
+
+Implements [PSR-0][2] autoloader for your apps.
+
+[1]: https://docs.phalconphp.com/en/latest/api/Phalcon_Loader.html
+[2]: http://www.php-fig.org/psr/psr-0/

--- a/codeception.yml
+++ b/codeception.yml
@@ -22,7 +22,8 @@ coverage:
     enabled: true
     whitelist:
         include:
-            - Library/*
+            - Library/*.php
+
 extensions:
     enabled:
         - Codeception\Extension\RunFailed

--- a/tests/unit/Loader/ExtendedTest.php
+++ b/tests/unit/Loader/ExtendedTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Phalcon\Test\Loader;
+
+use Phalcon\Loader\Extended;
+use Codeception\TestCase\Test;
+use UnitTester;
+
+/**
+ * \Phalcon\Test\Loader\ExtendedTest
+ * Tests the Phalcon\Loader\Extended component
+ *
+ * @copyright (c) 2011-2015 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @package   Phalcon\Loader
+ * @group     Loader
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class ExtendedTest extends Test
+{
+    /**
+     * UnitTester Object
+     * @var UnitTester
+     */
+    protected $tester;
+
+    /**
+     * executed before each test
+     */
+    protected function _before()
+    {
+    }
+
+    /**
+     * executed after each test
+     */
+    protected function _after()
+    {
+    }
+
+    public function testShouldAlwaysPreparePathsAndConvertToArray()
+    {
+        $loader = new Extended();
+
+        $this->assertTrue($loader->getNamespaces() === null);
+
+        $loader->registerNamespaces(
+            [
+                'Example\Base' => __DIR__ . '/TestLib/Extended/Example/Base/'
+            ]
+        );
+
+        $this->assertEquals(
+            $loader->getNamespaces(),
+            [
+                'Example\Base' => [__DIR__ . '/TestLib/Extended/Example/Base/']
+            ]
+        );
+    }
+
+    public function testShouldRegisterNamespacesForMultipleDirectories()
+    {
+        $loader = new Extended();
+
+        $loader->registerNamespaces(
+            [
+                'Example\Adapter' => [
+                    __DIR__ . '/TestLib/Extended/Example/Adapter/src/',
+                    __DIR__ . '/TestLib/Extended/Example/Adapter/test/',
+                ]
+            ]
+        );
+
+        $this->assertEquals(
+            $loader->getNamespaces(),
+            [
+                'Example\Adapter' => [
+                    __DIR__ . '/TestLib/Extended/Example/Adapter/src/',
+                    __DIR__ . '/TestLib/Extended/Example/Adapter/test/',
+                ]
+            ]
+        );
+
+        $loader->register();
+
+        $this->assertTrue(class_exists('Example\Adapter\SrcClass'));
+        $srcClass = new \Example\Adapter\SrcClass();
+        $this->assertEquals(get_class($srcClass), 'Example\Adapter\SrcClass');
+
+        $this->assertTrue(class_exists('Example\Adapter\TestClass'));
+        $testClass = new \Example\Adapter\TestClass();
+        $this->assertEquals(get_class($testClass), 'Example\Adapter\TestClass');
+    }
+
+    public function testShouldMergeNamespacesForMultipleDirectories()
+    {
+        $loader = new Extended();
+
+        $loader->registerNamespaces(
+            [
+                'Example\Base' => __DIR__ . '/TestLib/Extended/Example/Base/'
+            ]
+        );
+
+        $loader->registerNamespaces(
+            [
+                'Example\Adapter' => [
+                    __DIR__ . '/TestLib/Extended/Example/Adapter/src/'
+                ]
+            ],
+            true
+        );
+
+        $loader->registerNamespaces(
+            [
+                'Example\Adapter' => [
+                    __DIR__ . '/TestLib/Extended/Example/Adapter/test/',
+                ]
+            ],
+            true
+        );
+
+        $this->assertEquals(
+            $loader->getNamespaces(),
+            [
+                'Example\Base' => [__DIR__ . '/TestLib/Extended/Example/Base/'],
+                'Example\Adapter' => [
+                    __DIR__ . '/TestLib/Extended/Example/Adapter/src/',
+                    __DIR__ . '/TestLib/Extended/Example/Adapter/test/',
+                ]
+            ]
+        );
+    }
+
+    public function testShouldMergeForEmptyNamespace()
+    {
+        $loader = new Extended();
+
+        $loader->registerNamespaces(
+            [
+                'Example\Base' => __DIR__ . '/TestLib/Extended/Example/Base/'
+            ],
+            true
+        );
+
+        $this->assertEquals(
+            $loader->getNamespaces(),
+            [
+                'Example\Base' => [__DIR__ . '/TestLib/Extended/Example/Base/'],
+            ]
+        );
+    }
+
+    /**
+     * @dataProvider providerWrongClassName
+     * @param        mixed $className
+     */
+    public function testShouldReceiveWhenClassNameIsWrong($className)
+    {
+        $loader = new Extended();
+
+        $this->assertFalse($loader->autoLoad($className));
+    }
+
+    public function providerWrongClassName()
+    {
+        return [
+            [1],
+            [3.14],
+            [null],
+            [false],
+            [true],
+            [''],
+            [new \stdClass()],
+            [[]],
+            [function () { return 'foo'; }],
+        ];
+    }
+}

--- a/tests/unit/Loader/TestLib/Extended/Example/Adapter/src/SrcClass.php
+++ b/tests/unit/Loader/TestLib/Extended/Example/Adapter/src/SrcClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Example\Adapter;
+
+class SrcClass
+{
+}

--- a/tests/unit/Loader/TestLib/Extended/Example/Adapter/test/TestClass.php
+++ b/tests/unit/Loader/TestLib/Extended/Example/Adapter/test/TestClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Example\Adapter;
+
+class TestClass
+{
+}

--- a/tests/unit/Loader/TestLib/Extended/Example/Base/ExtClass.php
+++ b/tests/unit/Loader/TestLib/Extended/Example/Base/ExtClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Example\Base;
+
+class ExtClass
+{
+}


### PR DESCRIPTION
This component extends [Phalcon\Loader][1] and added ability to
set multiple directories per namespace.

```php
use Phalcon\Loader\Extended as Loader;

// Creates the autoloader
$loader = new Loader();

// Register some namespaces
$loader->registerNamespaces(
    [
        'Example\Base' => 'vendor/example/base/',
        'Some\Adapters' => [
            'vendor/example/adapters/src/',
            'vendor/example/adapters/test/',
        ]
    ]
);

// Register autoloader
$loader->register();

// Requiring this class will automatically include
// file vendor/example/adapters/src/Some.php
$adapter = Example\Adapters\Some();

// Requiring this class will automatically include
// file vendor/example/adapters/test/Another.php
$adapter = Example\Adapters\Another();
```

Refs: https://github.com/phalcon/cphalcon/issues/11021

[1]: https://docs.phalconphp.com/en/latest/api/Phalcon_Loader.html