### PR TITLE
Making header line parsing more grasiously

### DIFF
--- a/Library/Phalcon/Http/Client/Header.php
+++ b/Library/Phalcon/Http/Client/Header.php
@@ -143,11 +143,11 @@ class Header implements \Countable
         }
 
         $status = array();
-        if (preg_match('/^HTTP\/(\d(?:\.\d)?)\s+(\d{3})\s+(.+)$/i', $content[0], $status)) {
+        if (preg_match('%^HTTP/(\d(?:\.\d)?)\s+(\d{3})\s?+(.+)?$%i', $content[0], $status)) {
             $this->status = array_shift($content);
             $this->version = $status[1];
             $this->statusCode = intval($status[2]);
-            $this->statusMessage = $status[3];
+            $this->statusMessage = isset($status[3]) ? $status[3] : '';
         }
 
         foreach ($content as $field) {


### PR DESCRIPTION
Though rfc2616 6.1 doesn't declare the reason-phrase as mandatory, some servers may omit that message, causing the regex not to match.