### PR TITLE
Making header line parsing more grasiously

### DIFF
--- a/Library/Phalcon/Http/Client/Header.php
+++ b/Library/Phalcon/Http/Client/Header.php
@@ -123,11 +123,11 @@ class Header implements \Countable
         }
 
         $status = array();
-        if (preg_match('/^HTTP\/(\d(?:\.\d)?)\s+(\d{3})\s+(.+)$/i', $content[0], $status)) {
+        if (preg_match('%^HTTP/(\d(?:\.\d)?)\s+(\d{3})\s?+(.+)?$%i', $content[0], $status)) {
             $this->status = array_shift($content);
             $this->version = $status[1];
             $this->statusCode = intval($status[2]);
-            $this->statusMessage = $status[3];
+            $this->statusMessage = isset($status[3]) ? $status[3] : '';
         }
 
         foreach ($content as $field) {

--- a/tests/unit/Http/HeaderTest.php
+++ b/tests/unit/Http/HeaderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Phalcon\Tests\Http;
+
+use Codeception\TestCase\Test;
+use Phalcon\Http\Client\Header;
+use UnitTester;
+
+/**
+ * Class HeaderTest
+ * @package Phalcon\Tests\Http
+ */
+class HeaderTest extends Test
+{
+    /**
+     * UnitTester Object
+     * @var UnitTester
+     */
+    protected $tester;
+
+    /**
+     * executed before each test
+     */
+    protected function _before()
+    {
+    }
+
+    /**
+     * executed after each test
+     */
+    protected function _after()
+    {
+    }
+
+    public function testHeaderParsedCorrectlyBothWithAndWithoutMessage()
+    {
+        $stringHeaderWithMessage = "HTTP/1.1 200 OK\r\nDate: Fri, 06 Nov 2015 10:30:15 GMT\r\nServer: Apache\r\nX-Server: http-devel, test.test\r\nCache-Control: max-age=0\r\nExpires: Fri, 06 Nov 2015 10:30:15 GMT\r\nX-Server: nb\r\nContent-Type: application/json;charset=UTF-8\r\nTransfer-Encoding: chunked";
+        $stringHeaderNoMessage = "HTTP/1.1 550";
+
+        $testData = [
+            $stringHeaderWithMessage => [
+                "statusCode" => 200,
+                "statusMessage" => "OK",
+                "status" => "HTTP/1.1 200 OK",
+            ],
+            $stringHeaderNoMessage => [
+                "statusCode" => 550,
+                "statusMessage" => "",
+                "status" => "HTTP/1.1 550",
+            ],
+        ];
+
+        foreach ($testData as $stringHeader => $expected) {
+            $header = new Header();
+            $header->parse($stringHeader);
+            $this->assertEquals($header->statusCode, $expected["statusCode"]);
+            $this->assertEquals($header->statusMessage, $expected["statusMessage"]);
+            $this->assertEquals($header->status, $expected["status"]);
+        }
+    }
+}


### PR DESCRIPTION
Though rfc2616 6.1 doesn't declare the reason-phrase as mandatory, some servers may omit that message, causing the regex not to match.