### PR TITLE
Volt minifier

### DIFF
--- a/Library/Phalcon/Mvc/View/Engine/README.md
+++ b/Library/Phalcon/Mvc/View/Engine/README.md
@@ -233,3 +233,31 @@ $di->set('view', function() use ($config) {
 	return $view;
 });
 ```
+
+VoltMinifier
+------------
+This adapter extends the Volt adapter and compiler to enable html-minification. The minification is done on the compiled template before saving it to the cache, so it will not affect the performance after the first rendering. The minifier will not affect templates contining ```<script>```, ```<code>```, ```<pre>```, ```<textarea>``` or tags containing ```value="...."```. This should make it safe to use with javascript in templates, as long as it's surrounded with the proper tags. Minification can also selectively be disabled for .volt-files by adding the comment ```{# no-minify #}``` anywhere in the template. 
+
+Register the adapter in the view component:
+```php
+//Setting up the view component
+$di->set('view', function() use ($di) {
+
+	$view = new \Phalcon\Mvc\View();
+
+	$view->setViewsDir('../app/views/');
+
+	$volt = new \Phalcon\Mvc\View\Engine\VoltMinifyer($view, $di);
+	$options = [
+		'compiledPath' => __DIR__ . '/cache/',
+		'compiledSeparator' => '_'
+	];
+	$volt->setOptions($options);
+
+	$view->registerEngines(array(
+		'.volt' => $volt
+	));
+
+	return $view;
+});
+```

--- a/Library/Phalcon/Mvc/View/Engine/Volt/MinifierCompiler.php
+++ b/Library/Phalcon/Mvc/View/Engine/Volt/MinifierCompiler.php
@@ -1,0 +1,104 @@
+<?php
+namespace Phalcon\Mvc\View\Engine\Volt;
+
+/**
+ * Phalcon\Mvc\View\Engine\Volt\MinifierCompiler
+ *
+ * Run basic html-minification on the compiled templates, taking
+ * care to avoid minification of javascrip and other special cases.
+ */
+class MinifierCompiler extends Compiler
+{
+    /** @var bool $_minify */
+    protected $minify = true;
+
+    /**
+     * Enable/disable minification
+     * @param bool $shouldMinify
+     */
+    public function setMinify($shouldMinify)
+    {
+        $this->minify = $shouldMinify;
+    }
+
+    /**
+     * Override _compileSource to minify the compiled output before it's stored in the cache.
+     *
+     * @inheritdoc
+     */
+    // @codingStandardsIgnoreStart
+    protected function _compileSource($viewCode, $extendsMode = NULL)
+    {
+    // @codingStandardsIgnoreEnd
+        $compilation = parent::_compileSource($viewCode, $extendsMode);
+
+        // Check the original input for the no-minify comment, as it's stripped by the compiler.
+        if ($this->minify === false || preg_match('/{# no-minify #}/', $viewCode)) {
+            return $compilation;
+        }
+
+        if (is_array($compilation)) {
+            foreach ($compilation as &$part) {
+                if (is_string($part)) {
+                    $part = $this->minify($part);
+                } elseif (is_array($part)) {
+                    foreach ($part as &$subPart) {
+                        // Check for PHVOLT_T_RAW_FRAGMENT (type 357)
+                        if (isset($subPart['type']) && $subPart['type'] == 357) {
+                            $subPart['value'] = $this->minify($subPart['value']);
+                        }
+                    }
+                }
+            }
+        } else {
+            $compilation = $this->minify($compilation);
+        }
+
+        return $compilation;
+    }
+
+    /**
+     * Get the minified value.
+     *
+     * All credit to Trevor Fitzgerald for the regex here.
+     * See the original here: http://bit.ly/U7mv7a.
+     *
+     * @param string $block
+     *
+     * @return string
+     */
+    protected function minify($block)
+    {
+        if ($this->shouldMinify($block)) {
+            $replace = [
+                '/<!--[^\[](.*?)[^\]]-->/s' => '',
+                '/<\?php/' => '<?php ',
+                "/\n([\S])/" => ' $1',
+                "/\r/" => '',
+                "/\n/" => '',
+                "/\t/" => ' ',
+                '/ +/' => ' ',
+            ];
+
+            $block = preg_replace(array_keys($replace), array_values($replace), $block);
+        }
+
+        return $block;
+    }
+
+    /**
+     * Determine if the block should be minified.
+     *
+     * @param string $value
+     *
+     * @return bool
+     */
+    protected function shouldMinify($block)
+    {
+        return (
+            !preg_match('/<(code|pre|textarea)/', $block) &&
+            !preg_match('/<script[^\??>]*>[^<\/script>]/', $block) &&
+            !preg_match('/value=("|\')(.*)([ ]{2,})(.*)("|\')/', $block)
+        );
+    }
+}

--- a/Library/Phalcon/Mvc/View/Engine/VoltMinifier.php
+++ b/Library/Phalcon/Mvc/View/Engine/VoltMinifier.php
@@ -1,0 +1,50 @@
+<?php
+namespace Phalcon\Mvc\View\Engine;
+
+use Phalcon\Mvc\ViewBaseInterface;
+use Phalcon\DiInterface;
+use Phalcon\Mvc\View\Engine\Volt\MinifierCompiler;
+
+/**
+ * Phalcon\Mvc\View\Engine\VoltMinifier
+ * Adapter using a html-minifying compiler for volt templates. Minification is
+ * performed on the compiled templates before they are stored in the cache.
+ */
+class VoltMinifier extends Volt
+{
+    /**
+     * @inheritdoc
+     */
+    public function __construct(ViewBaseInterface $view, DiInterface $dependencyInjector = null)
+    {
+        parent::__construct($view, $dependencyInjector);
+
+        $this->_compiler = new MinifierCompiler($view);
+        $this->_compiler->setDi($dependencyInjector);
+    }
+
+    /**
+     * As the compiler is set in the constructor, the options will not be set automatically,
+     * so let setOptions pass the options to the compiler.
+     *
+     * @inheritdoc
+     */
+    public function setOptions(array $options)
+    {
+        parent::setOptions($options);
+        if (is_array($options)) {
+            $this->_compiler->setOptions($options);
+        }
+    }
+
+    /**
+     * Enable/disable minification
+     * @param bool $shouldMinify
+     */
+    public function setMinify($shouldMinify)
+    {
+        if ($this->_compiler instanceof MinifierCompiler) {
+            $this->_compiler->setMinify($shouldMinify);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 * [Phalcon\Mvc\View\Engine\Mustache](Library/Phalcon/Mvc/View/Engine) - Adapter for Mustache (@phalcon)
 * [Phalcon\Mvc\View\Engine\Twig](Library/Phalcon/Mvc/View/Engine) - Adapter for Twig (@phalcon)
 * [Phalcon\Mvc\View\Engine\Smarty](Library/Phalcon/Mvc/View/Engine) - Adapter for Smarty (@phalcon)
+* [Phalcon\Mvc\View\Engine\VoltMinifier](Library/Phalcon/Mvc/View/Engine) - Adapter for volt templates, with built in html minification (@thomas-brx)
 
 ### ORM Validators
 * [Phalcon\Mvc\Model\Validator\ConfirmationOf](Library/Phalcon/Mvc/Model/Validator) - Allows to validate if a field has a confirmation field with the same value (@suxxes)


### PR DESCRIPTION
Extends the Volt engine to perform basic html-minification of the compiled templates before they are cached.
The minification should be safe for html-templates, and will not touch templates or partials containing tags not suitable for minification, such as <script>, <textarea> etc.

As the minification is done prior to caching of the compiled template, it should not affect the overall performance.