### PR TITLE
Drops isDestroyed flag and allows the writing of empty data

### DIFF
--- a/Library/Phalcon/Session/Adapter/Database.php
+++ b/Library/Phalcon/Session/Adapter/Database.php
@@ -133,10 +133,6 @@ class Database extends Adapter implements AdapterInterface
      */
     public function write($sessionId, $data)
     {
-        if (empty($data)) {
-            return false;
-        }
-
         $options = $this->getOptions();
         $row = $options['db']->fetchOne(
             sprintf(

--- a/Library/Phalcon/Session/Adapter/Database.php
+++ b/Library/Phalcon/Session/Adapter/Database.php
@@ -31,13 +31,6 @@ use Phalcon\Session\Exception;
 class Database extends Adapter implements AdapterInterface
 {
     /**
-     * Flag to check if session is destroyed.
-     *
-     * @var boolean
-     */
-    protected $isDestroyed = false;
-
-    /**
      * {@inheritdoc}
      *
      * @param  array $options
@@ -140,7 +133,7 @@ class Database extends Adapter implements AdapterInterface
      */
     public function write($sessionId, $data)
     {
-        if ($this->isDestroyed || empty($data)) {
+        if (empty($data)) {
             return false;
         }
 
@@ -187,7 +180,7 @@ class Database extends Adapter implements AdapterInterface
      */
     public function destroy($session_id = null)
     {
-        if (!$this->isStarted() || $this->isDestroyed) {
+        if (!$this->isStarted()) {
             return true;
         }
 
@@ -195,7 +188,7 @@ class Database extends Adapter implements AdapterInterface
             $session_id = $this->getId();
         }
 
-        $this->isDestroyed = true;
+        $this->_started = false;
         $options = $this->getOptions();
         $result = $options['db']->execute(
             sprintf(


### PR DESCRIPTION
After destroying a session you might want to restart it again, the current implementation doesn't allow it unless you instantiate the adapter again.

I'm not sure why the isDestroyed flag is useful, please elucidate me. In my use case, I wanted to destroy a session and then start a new one. You can do that fine with PHP Sessions, so I believe you should be able to do that with the Phalcon adapter too. My patch drops isDestroyed all together.

Please let me know if you would like to have some tests, I might be able to provide some. My patch might have adverse effects, my primary intention with it is to start a discussion.