### PR TITLE
Drops isDestroyed flag, drops check for empty data

### DIFF
--- a/Library/Phalcon/Session/Adapter/Database.php
+++ b/Library/Phalcon/Session/Adapter/Database.php
@@ -32,13 +32,6 @@ use Phalcon\Db\AdapterInterface as DbAdapter;
 class Database extends Adapter implements AdapterInterface
 {
     /**
-     * Flag to check if session is destroyed.
-     *
-     * @var boolean
-     */
-    protected $isDestroyed = false;
-
-    /**
      * @var DbAdapter
      */
     protected $connection;
@@ -145,10 +138,6 @@ class Database extends Adapter implements AdapterInterface
      */
     public function write($sessionId, $data)
     {
-        if ($this->isDestroyed || empty($data)) {
-            return false;
-        }
-
         $options = $this->getOptions();
         $row = $this->connection->fetchOne(
             sprintf(
@@ -193,7 +182,7 @@ class Database extends Adapter implements AdapterInterface
      */
     public function destroy($session_id = null)
     {
-        if (!$this->isStarted() || $this->isDestroyed) {
+        if (!$this->isStarted()) {
             return true;
         }
 
@@ -201,7 +190,7 @@ class Database extends Adapter implements AdapterInterface
             $session_id = $this->getId();
         }
 
-        $this->isDestroyed = true;
+        $this->_started = false;
         $options = $this->getOptions();
         $result = $this->connection->execute(
             sprintf(


### PR DESCRIPTION
Ref #519, #517 

After destroying a session you might want to restart it again, the current
implementation doesn't allow it unless you instantiate the adapter again.
Removing the isDestroyed flag seems to fix the issue. Also, removing the
empty data check on writing allows the session data to be cleared and
fixes the bug where data was getting stuck in the session even after
deleting it.