### PR TITLE
Fixes Database::destroy

### DIFF
--- a/Library/Phalcon/Session/Adapter/Database.php
+++ b/Library/Phalcon/Session/Adapter/Database.php
@@ -201,9 +201,7 @@ class Database extends Adapter implements AdapterInterface
             [$session_id]
         );
 
-        session_regenerate_id();
-
-        return $result;
+        return $result && session_destroy();
     }
 
     /**


### PR DESCRIPTION
The call to session_regenerate_id has no place in the destroy method, it can actually mess things up.

I'm not sure why this was added to the destroy method but it seems wrong. I compared the destroy method of other Phalcon adapters just to make sure and none of them calls session_regenerate_id.