### PR TITLE
Bug Fix in Database.php to use $this->connection instead of $options['db']

### DIFF
--- a/Library/Phalcon/Session/Adapter/Database.php
+++ b/Library/Phalcon/Session/Adapter/Database.php
@@ -108,7 +108,7 @@ class Database extends Adapter implements AdapterInterface
         $maxLifetime = (int) ini_get('session.gc_maxlifetime');
 
         $options = $this->getOptions();
-        $row = $options['db']->fetchOne(
+        $row = $this->connection->fetchOne(
             sprintf(
                 'SELECT %s FROM %s WHERE %s = ? AND COALESCE(%s, %s) + %d >= ?',
                 $this->connection->escapeIdentifier($options['column_data']),


### PR DESCRIPTION
Updated read method to use $this->connection instead of $options['db'].  $options['db'] is unset in the constructor hence 'read' method is throwing a fatal error: 
Call to a member function fetchOne() on a non-object in /<path-to-lib>/lib/vendors/phalcon/incubator/Library/Phalcon/Session/Adapter/Database.php on line 111
with a PHP Notice: 
Undefined index: db in /<path-to-lib>/lib/vendors/phalcon/incubator/Library/Phalcon/Session/Adapter/Database.php on line 111