### PR TITLE
ACL Database 'allow' method to work with wildcards

### DIFF
--- a/Library/Phalcon/Acl/Adapter/Database.php
+++ b/Library/Phalcon/Acl/Adapter/Database.php
@@ -440,12 +440,14 @@ class Database extends Adapter
         /**
          * Check if the access is valid in the resource
          */
-        $sql = "SELECT COUNT(*) FROM {$this->resourcesAccesses} WHERE resources_name = ? AND access_name = ?";
-        $exists = $this->connection->fetchOne($sql, null, [$resourceName, $accessName]);
-        if (!$exists[0]) {
-            throw new Exception(
-                "Access '{$accessName}' does not exist in resource '{$resourceName}' in ACL"
-            );
+        if ($resourceName !== '*' && $accessName !== '*'){
+            $sql = "SELECT COUNT(*) FROM {$this->resourcesAccesses} WHERE resources_name = ? AND access_name = ?";
+            $exists = $this->connection->fetchOne($sql, null, [$resourceName, $accessName]);
+            if (!$exists[0]) {
+                throw new Exception(
+                    "Access '{$accessName}' does not exist in resource '{$resourceName}' in ACL"
+                );
+            }
         }
 
         /**


### PR DESCRIPTION
ACL Database adapter will now work with wildcards for the role/resource (or both) with the 'allow' method 
Issue: #568