### PR TITLE
isAllowed bugfix for Database ACL Adapter

### DIFF
--- a/Library/Phalcon/Acl/Adapter/Database.php
+++ b/Library/Phalcon/Acl/Adapter/Database.php
@@ -407,7 +407,7 @@ class Database extends Adapter
             // access_name should be given one or 'any'
             "AND access_name IN (?, '*')",
             // order be the sum of bools for 'literals' before 'any'
-            "ORDER BY (roles_name != '*')+(resources_name != '*')+(access_name != '*') DESC",
+            "ORDER BY ".$this->connection->escapeIdentifier('allowed')." DESC",
             // get only one...
             'LIMIT 1'
         ]);


### PR DESCRIPTION
Role inheritance when it comes to resource access is not working as expected; the built-in adapters in Phalcon (Memory & Redis) have different outcomes to the Incubator Database adapter.

I've written a simple test to prove that there is indeed an issue with the logic of the SQL based ACL Adapters.

The tl;dr of the test is:
- Create 'Staff' role
- Create 'Administrator' role inheriting the Staff role
- Create 'Example' reason with action 'read'
- Allow 'Administrator' role to access 'Example' resource 'read' action
- Disallow or leave default 'Staff' role resource access
- Check isAllowed against 'Administrator' role
- ????
- Comes back as False despite there being explicit access

Tested: Memory, ACL, Database (MySQL & SQLLite)
Not tested: MongoDB

```php
<?php
$SqliteDbName = sprintf('example-%s.db', uniqid());
$dbConnections = [
  'Mysql' => new \Phalcon\Db\Adapter\Pdo\Mysql([
    "host" => "localhost",
    "dbname" => "acltest",
    "port" => 3306,
    "username" => "root",
    "password" => ""
  ]),
  'Sqlite' => new \Phalcon\Db\Adapter\Pdo\Sqlite([
      'dbname' => $SqliteDbName
  ])
];
foreach(['Mysql', 'Sqlite'] as $connectionAdapter){
  foreach([
    "CREATE TABLE `roles` (`name` VARCHAR(32) NOT NULL, `description` TEXT, PRIMARY KEY(`name`));",
    "CREATE TABLE `access_list` (`roles_name` VARCHAR(32) NOT NULL, `resources_name` VARCHAR(32) NOT NULL, `access_name` VARCHAR(32) NOT NULL, `allowed` INT(3) NOT NULL, PRIMARY KEY(`roles_name`, `resources_name`, `access_name`));",
    "CREATE TABLE `resources` (`name` VARCHAR(32) NOT NULL, `description` TEXT, PRIMARY KEY(`name`));",
    "CREATE TABLE `resources_accesses` (`resources_name` VARCHAR(32) NOT NULL, `access_name` VARCHAR(32) NOT NULL, PRIMARY KEY(`resources_name`, `access_name`));",
    "CREATE TABLE `roles_inherits` ( `roles_name` VARCHAR(32) NOT NULL, `roles_inherit` VARCHAR(32) NOT NULL, PRIMARY KEY(roles_name, roles_inherit));"
  ] as $tableCreate){
      $dbConnections[$connectionAdapter]->execute($tableCreate);
  }
}
$redis = new \Redis();
$redis->connect('10.10.1.204');

$acls = [
  'Mysql' => new \Phalcon\Acl\Adapter\Database(['db' => $dbConnections['Mysql'], 'roles' => 'roles', 'rolesInherits' => 'roles_inherits', 'resources' => 'resources', 'resourcesAccesses' => 'resources_accesses', 'accessList' => 'access_list']),
  'Sqlite' => new \Phalcon\Acl\Adapter\Database(['db' => $dbConnections['Sqlite'], 'roles' => 'roles', 'rolesInherits' => 'roles_inherits', 'resources' => 'resources', 'resourcesAccesses' => 'resources_accesses', 'accessList' => 'access_list']),
  'Memory' => new \Phalcon\Acl\Adapter\Memory(),
  'Redis' => new \Phalcon\Acl\Adapter\Redis($redis)
];
echo "Staff/Administrator allowed to access resource: Example, action: read?\n";
foreach(array_keys($acls) as $key){
  $acls[$key]->setDefaultAction(Phalcon\Acl::DENY);
  $acls[$key]->addRole('Staff');
  $acls[$key]->addRole('Staff/Administrator', 'Staff');
  $acls[$key]->addResource('Example', ['read']);
  $acls[$key]->allow('Staff/Administrator', '*', '*');
  echo sprintf("[%s] %s\n", $key, ($acls[$key]->isAllowed('Staff/Administrator', 'Example', 'read')) ? 'True' : 'False');
}
foreach([
    "DROP TABLE `roles`;",
    "DROP TABLE `access_list`;",
    "DROP TABLE `resources`;",
    "DROP TABLE `resources_accesses`;",
    "DROP TABLE `roles_inherits`;"
  ] as $tableDrop){
    $dbConnections['Mysql']->execute($tableDrop);
}

$dbConnections['Sqlite']->close();
unlink($SqliteDbName);
```
Will result in

```
Staff/Administrator allowed to access resource: Example, action: read?
[Mysql] False
[Sqlite] False
[Memory] True
[Redis] True
```

With the patch I've written the outcome of this test is

```
Staff/Administrator allowed to access resource: Example, action: read?
[Mysql] True
[Sqlite] True
[Memory] True
[Redis] True
```