### PR TITLE
Bug fixed in Phalcon\Mvc\Model\Behavior\NestedSet

### DIFF
--- a/Library/Phalcon/Mvc/Model/Behavior/NestedSet.php
+++ b/Library/Phalcon/Mvc/Model/Behavior/NestedSet.php
@@ -869,6 +869,8 @@ class NestedSet extends Behavior implements BehaviorInterface
     private function makeRoot($attributes, $whiteList)
     {
         $owner = $this->getOwner();
+        
+        $owner->{$this->rootAttribute} = 0;
         $owner->{$this->leftAttribute} = 1;
         $owner->{$this->rightAttribute} = 2;
         $owner->{$this->levelAttribute} = 1;


### PR DESCRIPTION
During creation of root node the rootAttribute remained empty and there was an error in attempt of record in database (like "SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'root' cannot be null").