### PR TITLE
add mysql INTERVAL units

### DIFF
--- a/Library/Phalcon/Db/Dialect/MysqlExtended.php
+++ b/Library/Phalcon/Db/Dialect/MysqlExtended.php
@@ -58,7 +58,7 @@ class MysqlExtended extends Mysql
                             return 'INTERVAL ' . $this->getSqlExpression($expression["arguments"][0]) . ' DAY';
                         case "'WEEK'":
                             return 'INTERVAL ' . $this->getSqlExpression($expression["arguments"][0]) . ' WEEK';
-                         case "'MONTH'":
+                        case "'MONTH'":
                             return 'INTERVAL ' . $this->getSqlExpression($expression["arguments"][0]) . ' MONTH';
                         case "'QUARTER'":
                             return 'INTERVAL ' . $this->getSqlExpression($expression["arguments"][0]) . ' QUARTER';
@@ -66,7 +66,6 @@ class MysqlExtended extends Mysql
                             return 'INTERVAL ' . $this->getSqlExpression($expression["arguments"][0]) . ' YEAR';
                         default:
                             throw new \Exception('DATE_INTERVAL unit is not supported');
-                          
                     }
                     break;
 

--- a/Library/Phalcon/Db/Dialect/MysqlExtended.php
+++ b/Library/Phalcon/Db/Dialect/MysqlExtended.php
@@ -46,12 +46,27 @@ class MysqlExtended extends Mysql
                     }
 
                     switch ($expression["arguments"][1]['value']) {
+                        case "'MICROSECOND'":
+                            return 'INTERVAL ' . $this->getSqlExpression($expression["arguments"][0]) . ' MICROSECOND';
+                        case "'SECOND'":
+                            return 'INTERVAL ' . $this->getSqlExpression($expression["arguments"][0]) . ' SECOND';
+                        case "'MINUTE'":
+                            return 'INTERVAL ' . $this->getSqlExpression($expression["arguments"][0]) . ' MINUTE';
+                        case "'HOUR'":
+                            return 'INTERVAL ' . $this->getSqlExpression($expression["arguments"][0]) . ' HOUR';
                         case "'DAY'":
                             return 'INTERVAL ' . $this->getSqlExpression($expression["arguments"][0]) . ' DAY';
-                        case "'MONTH'":
+                        case "'WEEK'":
+                            return 'INTERVAL ' . $this->getSqlExpression($expression["arguments"][0]) . ' WEEK';
+                         case "'MONTH'":
                             return 'INTERVAL ' . $this->getSqlExpression($expression["arguments"][0]) . ' MONTH';
+                        case "'QUARTER'":
+                            return 'INTERVAL ' . $this->getSqlExpression($expression["arguments"][0]) . ' QUARTER';
                         case "'YEAR'":
                             return 'INTERVAL ' . $this->getSqlExpression($expression["arguments"][0]) . ' YEAR';
+                        default:
+                            throw new \Exception('DATE_INTERVAL unit is not supported');
+                          
                     }
                     break;
 


### PR DESCRIPTION
basic units have been added, see http://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_date-add,
the more complex ones remain to be added (like 'SECOND_MICROSECOND'), they may be associated with formatting regexp check (?)