### PR TITLE
Add PATCH support, and allow class to be extended

### DIFF
--- a/Library/Phalcon/Http/Client/Provider/Curl.php
+++ b/Library/Phalcon/Http/Client/Provider/Curl.php
@@ -56,7 +56,7 @@ class Curl extends Request
         return $request;
     }
 
-    private function initOptions()
+    protected function initOptions()
     {
         $this->setOptions(array(
             CURLOPT_RETURNTRANSFER  => true,
@@ -92,7 +92,7 @@ class Curl extends Request
         $this->setOption(CURLOPT_CONNECTTIMEOUT, $timeout);
     }
 
-    private function send($customHeader = array(), $fullResponse = false)
+    protected function send($customHeader = array(), $fullResponse = false)
     {
         if (!empty($customHeader)) {
             $header = $customHeader;
@@ -245,5 +245,17 @@ class Curl extends Request
         $this->initPostFields($params, $useEncoding);
 
         return $this->send($customHeader, $fullResponse);
+    }
+    
+    public function patch($uri, $params = array(), $useEncoding = true, $customHeader = array(), $fullResponse = false)
+    {
+      $this->setOptions(array(
+        CURLOPT_URL           => $this->resolveUri($uri),
+        CURLOPT_POST          => true,
+        CURLOPT_CUSTOMREQUEST => 'PATCH'
+      ));
+      
+      $this->initPostFields($params, $useEncoding);
+      return $this->send($customHeader, $fullResponse);
     }
 }

--- a/Library/Phalcon/Http/Client/Provider/Curl.php
+++ b/Library/Phalcon/Http/Client/Provider/Curl.php
@@ -249,13 +249,13 @@ class Curl extends Request
     
     public function patch($uri, $params = array(), $useEncoding = true, $customHeader = array(), $fullResponse = false)
     {
-      $this->setOptions(array(
-        CURLOPT_URL           => $this->resolveUri($uri),
-        CURLOPT_POST          => true,
-        CURLOPT_CUSTOMREQUEST => 'PATCH'
-      ));
+        $this->setOptions(array(
+          CURLOPT_URL           => $this->resolveUri($uri),
+          CURLOPT_POST          => true,
+          CURLOPT_CUSTOMREQUEST => 'PATCH'
+        ));
       
-      $this->initPostFields($params, $useEncoding);
-      return $this->send($customHeader, $fullResponse);
+        $this->initPostFields($params, $useEncoding);
+        return $this->send($customHeader, $fullResponse);
     }
 }


### PR DESCRIPTION
The client is missing PATCH support. Extending the class is not an option because the initPostFields() and send() methods are private.
The proposed change adds PATCH support, and makes the aforementioned functions protected to support extending the class.