### PR TITLE
Add PATCH support, and allow class to be extended

### DIFF
--- a/Library/Phalcon/Http/Client/Provider/Curl.php
+++ b/Library/Phalcon/Http/Client/Provider/Curl.php
@@ -92,7 +92,7 @@ class Curl extends Request
         $this->setOption(CURLOPT_CONNECTTIMEOUT, $timeout);
     }
 
-    private function send($customHeader = array(), $fullResponse = false)
+    protected function send($customHeader = array(), $fullResponse = false)
     {
         if (!empty($customHeader)) {
             $header = $customHeader;
@@ -134,7 +134,7 @@ class Curl extends Request
      *
      * @return void
      */
-    private function initPostFields($params, $useEncoding = true)
+    protected function initPostFields($params, $useEncoding = true)
     {
         if (is_array($params)) {
             foreach ($params as $param) {
@@ -240,6 +240,19 @@ class Curl extends Request
             CURLOPT_URL           => $this->resolveUri($uri),
             CURLOPT_POST          => true,
             CURLOPT_CUSTOMREQUEST => Method::PUT,
+        ));
+
+        $this->initPostFields($params, $useEncoding);
+
+        return $this->send($customHeader, $fullResponse);
+    }
+
+    public function patch($uri, $params = array(), $useEncoding = true, $customHeader = array(), $fullResponse = false)
+    {
+        $this->setOptions(array(
+            CURLOPT_URL           => $this->resolveUri($uri),
+            CURLOPT_POST          => true,
+            CURLOPT_CUSTOMREQUEST => Method::PATCH,
         ));
 
         $this->initPostFields($params, $useEncoding);

--- a/Library/Phalcon/Http/Client/Provider/Stream.php
+++ b/Library/Phalcon/Http/Client/Provider/Stream.php
@@ -82,7 +82,7 @@ class Stream extends Request
         throw new HttpException($errstr, $errno);
     }
 
-    private function send($uri)
+    protected function send($uri)
     {
         if (count($this->header) > 0) {
             $this->setOption('header', $this->header->build(Header::BUILD_FIELDS));
@@ -99,7 +99,7 @@ class Stream extends Request
         return $response;
     }
 
-    private function initPostFields($params)
+    protected function initPostFields($params)
     {
         if (!empty($params) && is_array($params)) {
             $this->header->set('Content-Type', 'application/x-www-form-urlencoded');
@@ -191,6 +191,15 @@ class Stream extends Request
     public function put($uri, $params = array())
     {
         $this->setOption('method', Method::PUT);
+
+        $this->initPostFields($params);
+
+        return $this->send($this->resolveUri($uri));
+    }
+
+    public function patch($uri, $params = array())
+    {
+        $this->setOption('method', Method::PATCH);
 
         $this->initPostFields($params);
 


### PR DESCRIPTION
The client is missing PATCH support. Extending the class is not an option because the initPostFields() and send() methods are private.
The proposed change adds PATCH support, and makes the aforementioned functions protected to support extending the class.