### PR TITLE
Added Annotations/Adapter/Aerospike

### DIFF
--- a/Library/Phalcon/Annotations/Adapter/Aerospike.php
+++ b/Library/Phalcon/Annotations/Adapter/Aerospike.php
@@ -1,0 +1,137 @@
+<?php
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Framework                                                      |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2016 Phalcon Team (http://www.phalconphp.com)       |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file docs/LICENSE.txt.                        |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Serghei Iakovlev <serghei@phalconphp.com>                     |
+  +------------------------------------------------------------------------+
+*/
+
+namespace Phalcon\Annotations\Adapter;
+
+use Phalcon\Annotations\Exception;
+use Phalcon\Cache\Frontend\Data as FrontendData;
+use Phalcon\Cache\Backend\Aerospike as BackendAerospike;
+
+/**
+ * Class Aerospike
+ *
+ * Stores the parsed annotations to the Aerospike database.
+ * This adapter is suitable for production.
+ *
+ *<code>
+ * use Phalcon\Annotations\Adapter\Aerospike;
+ *
+ * $annotations = new Aerospike([
+ *     'hosts' => [
+ *         ['addr' => '127.0.0.1', 'port' => 3000]
+ *     ],
+ *     'persistent' => true,
+ *     'namespace'  => 'test',
+ *     'prefix'     => 'annotations_',
+ *     'lifetime'   => 8600,
+ *     'options'    => [
+ *         \Aerospike::OPT_CONNECT_TIMEOUT => 1250,
+ *         \Aerospike::OPT_WRITE_TIMEOUT   => 1500
+ *     ]
+ * ]);
+ *</code>
+ *
+ * @package Phalcon\Annotations\Adapter
+ */
+class Aerospike extends Base
+{
+    /**
+     * @var BackendAerospike
+     */
+    protected $aerospike;
+
+    /**
+     * Default Aerospike namespace
+     * @var string
+     */
+    protected $namespace = 'test';
+
+    /**
+     * The Aerospike Set for store sessions
+     * @var string
+     */
+    protected $set = 'annotations';
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param array $options Options array
+     * @throws Exception
+     */
+    public function __construct(array $options = [])
+    {
+        if (!isset($options['hosts']) ||
+            !is_array($options['hosts']) ||
+            !isset($options['hosts'][0]) ||
+            !is_array($options['hosts'][0])
+        ) {
+            throw new Exception('No hosts given in options');
+        }
+
+        if (isset($options['namespace'])) {
+            $this->namespace = $options['namespace'];
+        }
+
+        if (isset($options['set']) && !empty($options['set'])) {
+            $this->set = $options['set'];
+        }
+
+        if (!isset($options['persistent'])) {
+            $options['persistent'] = false;
+        }
+
+        if (!isset($options['options']) || !is_array($options['options'])) {
+            $options['options'] = [];
+        }
+
+        parent::__construct($options);
+
+        $this->aerospike = new BackendAerospike(
+            new FrontendData(['lifetime' => $this->options['lifetime']]),
+            [
+                'hosts'      => $this->options['hosts'],
+                'namespace'  => $this->namespace,
+                'set'        => $this->set,
+                'prefix'     => $this->options['lifetime'],
+                'persistent' => (bool) $this->options['persistent'],
+                'options'    => $this->options['options'],
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return BackendAerospike
+     */
+    protected function getCacheBackend()
+    {
+        return $this->aerospike;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param string $key
+     * @return string
+     */
+    protected function prepareKey($key)
+    {
+        return strval($key);
+    }
+}

--- a/Library/Phalcon/Annotations/Adapter/README.md
+++ b/Library/Phalcon/Annotations/Adapter/README.md
@@ -38,3 +38,28 @@ $di->set('annotations', function () {
     ]);
 });
 ```
+
+## Aerospike
+
+Stores the parsed annotations to the Aerospike database.
+This adapter uses a `Phalcon\Cache\Backend\Aerospike` backend to store the cached content:
+
+```php
+use Phalcon\Annotations\Adapter\Aerospike;
+
+$di->set('annotations', function () {
+    return new Aerospike([
+        'hosts' => [
+            ['addr' => '127.0.0.1', 'port' => 3000]
+        ],
+        'persistent' => true,
+        'namespace'  => 'test',
+        'prefix'     => 'annotations_',
+        'lifetime'   => 8600,
+        'options'    => [
+            \Aerospike::OPT_CONNECT_TIMEOUT => 1250,
+            \Aerospike::OPT_WRITE_TIMEOUT   => 1500
+        ]
+    ]);
+});
+```

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ See [CONTRIBUTING.md](docs/CONTRIBUTING.md)
 ### Annotations
 * [Phalcon\Annotations\Adapter\Memcached](Library/Phalcon/Annotations/Adapter) - Memcached adapter for storing annotations (@igusev)
 * [Phalcon\Annotations\Adapter\Redis](Library/Phalcon/Annotations/Adapter) - Redis adapter for storing annotations (@sergeyklay)
+* [Phalcon\Annotations\Adapter\Aerospike](Library/Phalcon/Annotations/Adapter) - Aerospike adapter for storing annotations (@sergeyklay)
 
 ### Behaviors
 * [Phalcon\Mvc\Model\Behavior\Blameable](Library/Phalcon/Mvc/Model/Behavior) - logs with every created or updated row in your database who created and who updated it (@phalcon)

--- a/tests/unit/Annotations/Adapter/AerospikeTest.php
+++ b/tests/unit/Annotations/Adapter/AerospikeTest.php
@@ -1,0 +1,331 @@
+<?php
+
+namespace Phalcon\Test\Annotations\Adapter;
+
+use UnitTester;
+use ReflectionMethod;
+use ReflectionProperty;
+use Codeception\TestCase\Test;
+use Phalcon\Annotations\Adapter\Aerospike;
+
+/**
+ * \Phalcon\Test\Annotations\Adapter\AerospikeTest
+ * Tests for Phalcon\Annotations\Adapter\Aerospike component
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @link      http://phalconphp.com/
+ * @package   Phalcon\Test\Annotations\Adapter
+ * @group     Annotation
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class AerospikeTest extends Test
+{
+    const BASE_CLASS = '\Phalcon\Annotations\Adapter\Aerospike';
+    const BACKEND_CLASS ='\Phalcon\Cache\Backend\Aerospike';
+
+    /**
+     * UnitTester Object
+     * @var UnitTester
+     */
+    protected $tester;
+
+    /**
+     * executed before each test
+     */
+    protected function _before()
+    {
+        if (!extension_loaded('aerospike')) {
+            $this->markTestSkipped('The aerospike module is not available.');
+        }
+    }
+
+    /**
+     * executed after each test
+     */
+    protected function _after()
+    {
+    }
+
+    public function testHasAerospikeProperty()
+    {
+        $this->assertClassHasAttribute('aerospike', self::BASE_CLASS);
+    }
+
+    public function testHasNamespaceProperty()
+    {
+        $this->assertClassHasAttribute('namespace', self::BASE_CLASS);
+    }
+
+    public function testHasSetProperty()
+    {
+        $this->assertClassHasAttribute('set', self::BASE_CLASS);
+    }
+
+    /**
+     * @dataProvider providerReadWrite
+     * @param string $key
+     * @param mixed $data
+     */
+    public function testShouldReadAndWriteToAerospikeWithoutPrefix($key, $data)
+    {
+        $object = new Aerospike(['hosts' => [['addr' => TEST_AS_HOST, 'port' => TEST_AS_PORT]]]);
+        $object->write($key, $data);
+
+        $this->assertEquals($data, $object->read($key));
+    }
+
+    /**
+     * @dataProvider providerReadWrite
+     * @param string $key
+     * @param mixed $data
+     */
+    public function testShouldReadAndWriteToAerospikeWithPrefix($key, $data)
+    {
+        $object = new Aerospike(['hosts' => [['addr' => TEST_AS_HOST, 'port' => TEST_AS_PORT]], 'prefix' => 'test_']);
+        $object->write($key, $data);
+
+        $this->assertEquals($data, $object->read($key));
+    }
+
+    public function testShouldGetCacheBackendThroughGetter()
+    {
+        $object = new Aerospike(['hosts' => [['addr' => TEST_AS_HOST, 'port' => TEST_AS_PORT]]]);
+
+        $reflectedMethod = new ReflectionMethod(get_class($object), 'getCacheBackend');
+        $reflectedMethod->setAccessible(true);
+        $this->assertInstanceOf(self::BACKEND_CLASS, $reflectedMethod->invoke($object));
+    }
+
+    public function testShouldGetCacheBackendThroughReflectionSetter()
+    {
+        $object = new Aerospike(['hosts' => [['addr' => TEST_AS_HOST, 'port' => TEST_AS_PORT]]]);
+        $mock = $this->getMock(self::BACKEND_CLASS, [], [], '', false);
+
+        $reflectedProperty = new ReflectionProperty(get_class($object), 'aerospike');
+        $reflectedProperty->setAccessible(true);
+        $reflectedProperty->setValue($object, $mock);
+
+        $reflectedMethod = new ReflectionMethod(get_class($object), 'getCacheBackend');
+        $reflectedMethod->setAccessible(true);
+        $this->assertInstanceOf(self::BACKEND_CLASS, $reflectedMethod->invoke($object));
+    }
+
+    /**
+     * @dataProvider providerKey
+     * @param mixed $key
+     */
+    public function testShouldPrepareKey($key)
+    {
+        $object = new Aerospike(['hosts' => [['addr' => TEST_AS_HOST, 'port' => TEST_AS_PORT]]]);
+        $reflectedMethod = new ReflectionMethod(get_class($object), 'prepareKey');
+        $reflectedMethod->setAccessible(true);
+
+        $this->assertEquals($key, $reflectedMethod->invoke($object, $key));
+    }
+
+    /**
+     * @dataProvider providerConstructor
+     * @param array $options
+     * @param array $expected
+     */
+    public function testShouldCreateRedisAdapterInstanceAndSetOptions($options, $expected)
+    {
+        $object = new Aerospike($options);
+        $reflectedProperty = new ReflectionProperty(get_class($object), 'options');
+        $reflectedProperty->setAccessible(true);
+
+        $this->assertEquals($expected, $reflectedProperty->getValue($object));
+    }
+
+    /**
+     * @dataProvider providerInvalidConstructor
+     * @param array $options
+     * @param string  $exceptionName
+     * @param string $exceptionMessage
+     */
+    public function testShouldCatchExceptionWhenInvalidParamsPassed($options, $exceptionName, $exceptionMessage)
+    {
+        $this->setExpectedException($exceptionName, $exceptionMessage);
+
+        new Aerospike($options);
+    }
+
+    public function providerReadWrite()
+    {
+        // This key is needed in order not to break your real data
+        $key = hash('sha256', json_encode([__CLASS__, __METHOD__, __FILE__, __LINE__]));
+
+        return [
+            'string' => [$key . '_test1', 'data1'],
+            'object' => [$key . '_test1', (object) ['key' => 'value']],
+            'array'  => [$key . '_test1', ['key' => 'value']],
+            'null'   => [$key . '_test1', null],
+            'int'    => [$key . '_test1', PHP_INT_MAX],
+            'float'  => [$key . '_test1', 3.14],
+            'class'  => [$key . '_test1', new \stdClass()],
+        ];
+    }
+
+    public function providerKey()
+    {
+        return [
+            ['key1'],
+            [1],
+            ['_key1']
+        ];
+    }
+
+    public function providerInvalidConstructor()
+    {
+        return [
+            [
+                [],
+                'Phalcon\Annotations\Exception',
+                'No hosts given in options'
+            ],
+            [
+                ['hosts' => null],
+                'Phalcon\Annotations\Exception',
+                'No hosts given in options'
+            ],
+            [
+                ['hosts' => []],
+                'Phalcon\Annotations\Exception',
+                'No hosts given in options'
+            ],
+            [
+                ['hosts' => [[]]],
+                'Phalcon\Cache\Exception',
+                'Aerospike failed to connect [-2]: Unable to find host parameter'
+            ]
+        ];
+    }
+
+    public function providerConstructor()
+    {
+        return [
+            [
+                [
+                    'hosts' => [['addr' => TEST_AS_HOST, 'port' => TEST_AS_PORT]],
+                    'lifetime' => 23
+                ],
+                [
+                    'hosts' => [['addr' => TEST_AS_HOST, 'port' => TEST_AS_PORT]],
+                    'lifetime' => 23,
+                    'prefix' => '',
+                    'persistent' => false,
+                    'options' => []
+                ]
+            ],
+            [
+                [
+                    'hosts' => [['addr' => TEST_AS_HOST, 'port' => TEST_AS_PORT]],
+                    'lifetime' => 23,
+                    'options' => [
+                        \Aerospike::OPT_CONNECT_TIMEOUT => 1250,
+                        \Aerospike::OPT_WRITE_TIMEOUT   => 1500
+                    ]
+                ],
+                [
+                    'hosts' => [['addr' => TEST_AS_HOST, 'port' => TEST_AS_PORT]],
+                    'lifetime' => 23,
+                    'prefix' => '',
+                    'persistent' => false,
+                    'options' => [
+                        \Aerospike::OPT_CONNECT_TIMEOUT => 1250,
+                        \Aerospike::OPT_WRITE_TIMEOUT   => 1500
+                    ]
+                ]
+            ],
+            [
+                [
+                    'hosts' => [['addr' => TEST_AS_HOST, 'port' => TEST_AS_PORT]],
+                    'lifetime' => 23,
+                    'persistent' => true
+                ],
+                [
+                    'hosts' => [['addr' => TEST_AS_HOST, 'port' => TEST_AS_PORT]],
+                    'lifetime' => 23,
+                    'prefix' => '',
+                    'persistent' => true,
+                    'options' => [],
+                ]
+            ],
+            [
+                [
+                    'hosts' => [['addr' => TEST_AS_HOST, 'port' => TEST_AS_PORT]],
+                    'prefix' => 'test_'
+                ],
+                [
+                    'hosts' => [['addr' => TEST_AS_HOST, 'port' => TEST_AS_PORT]],
+                    'lifetime' => 8600,
+                    'prefix' => 'test_',
+                    'persistent' => false,
+                    'options' => [],
+                ]
+            ],
+            [
+                [
+                    'hosts' => [['addr' => TEST_AS_HOST, 'port' => TEST_AS_PORT]],
+                    'randomValue' => 'test_'
+                ],
+                [
+                    'hosts' => [['addr' => TEST_AS_HOST, 'port' => TEST_AS_PORT]],
+                    'randomValue' => 'test_',
+                    'lifetime' => 8600,
+                    'prefix' => '',
+                    'persistent' => false,
+                    'options' => [],
+                ]
+            ],
+            [
+                [
+                    'hosts' => [['addr' => TEST_AS_HOST, 'port' => TEST_AS_PORT]],
+                    123 => 'test_'
+                ],
+                [
+                    'hosts' => [['addr' => TEST_AS_HOST, 'port' => TEST_AS_PORT]],
+                    123 => 'test_',
+                    'lifetime' => 8600,
+                    'prefix' => '',
+                    'persistent' => false,
+                    'options' => [],
+                ]
+            ],
+            [
+                [
+                    'hosts' => [['addr' => TEST_AS_HOST, 'port' => TEST_AS_PORT]],
+                    'lifetime' => 24,
+                    'prefix' => 'test_',
+                ],
+                [
+                    'hosts' => [['addr' => TEST_AS_HOST, 'port' => TEST_AS_PORT]],
+                    'lifetime' => 24,
+                    'prefix' => 'test_',
+                    'persistent' => false,
+                    'options' => [],
+                ]
+            ],
+            [
+                [
+                    'hosts' => [['addr' => TEST_AS_HOST, 'port' => TEST_AS_PORT]],
+                ],
+                [
+                    'hosts' => [['addr' => TEST_AS_HOST, 'port' => TEST_AS_PORT]],
+                    'lifetime' => 8600,
+                    'prefix' => '',
+                    'persistent' => false,
+                    'options' => [],
+                ]
+            ],
+
+        ];
+    }
+}


### PR DESCRIPTION
Stores the parsed annotations to the Aerospike database.
This adapter uses a `Phalcon\Cache\Backend\Aerospike` backend to store the cached content:

```php
use Phalcon\Annotations\Adapter\Aerospike;

$di->set('annotations', function () {
    return new Aerospike([
        'hosts' => [
            ['addr' => '127.0.0.1', 'port' => 3000]
        ],
        'persistent' => true,
        'namespace'  => 'test',
        'prefix'     => 'annotations_',
        'lifetime'   => 8600,
        'options'    => [
            \Aerospike::OPT_CONNECT_TIMEOUT => 1250,
            \Aerospike::OPT_WRITE_TIMEOUT   => 1500
        ]
    ]);
});