### PR TITLE
MongoDB save() bug

### DIFF
--- a/Library/Phalcon/Mvc/MongoCollection.php
+++ b/Library/Phalcon/Mvc/MongoCollection.php
@@ -137,7 +137,7 @@ abstract class MongoCollection extends PhalconCollection implements \MongoDB\BSO
         }
 
         if ($status->isAcknowledged()) {
-            $success==true;
+            $success=true;
 
             if ($exists===false) {
                 $this->_id=$status->getInsertedId();


### PR DESCRIPTION
`$success=true;` not  `$success==true;` 

Merge with current 2.1 branch