### PR TITLE
Fix `getConfig` function in `UnitTestCase` class

### DIFF
--- a/Library/Phalcon/Test/UnitTestCase.php
+++ b/Library/Phalcon/Test/UnitTestCase.php
@@ -168,7 +168,7 @@ abstract class UnitTestCase extends TestCase implements InjectionAwareInterface
     public function getConfig()
     {
         if (!$this->config instanceof Config && $this->getDI()->has('config')) {
-            return $this->getDI()->has('config');
+            return $this->getDI()->get('config');
         }
 
         return $this->config;


### PR DESCRIPTION
Now, return the Config object if service 'config' was found in the dependency injection container and variable $config not set.