### PR TITLE
Update the beanstalk queue to use duncan3dc/fork-helper:2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
   # Install Dependencies
   - composer self-update
   - travis_retry composer install --ignore-platform-reqs --prefer-source --no-interaction
-  - travis_retry composer require --ignore-platform-reqs "duncan3dc/fork-helper:*"
+  - travis_retry composer require --ignore-platform-reqs duncan3dc/fork-helper:$(if [[ "${TRAVIS_PHP_VERSION:0:1}" = "7" ]]; then echo "^2.0"; else echo "^1.0"; fi)
   # Pull images
   - docker pull phalconphp/php:${TRAVIS_PHP_VERSION}
   - docker pull phalconphp/zephir:${TRAVIS_PHP_VERSION}

--- a/tests/unit/Queue/Beanstalk/ExtendedTest.php
+++ b/tests/unit/Queue/Beanstalk/ExtendedTest.php
@@ -123,10 +123,10 @@ class ExtendedTest extends Test
      */
     public function testShouldDoWork()
     {
-        if (!class_exists('\duncan3dc\Helpers\Fork')) {
+        if (!class_exists('\duncan3dc\Helpers\Fork') && !class_exists('\duncan3dc\Forker\Fork')) {
             $this->markTestSkipped(sprintf(
-                '%s used as a dependency \duncan3dc\Helpers\Fork. You can install it by using' .
-                'composer require "duncan3dc/fork-helper":"*"',
+                '%s uses fork-helper as a dependency. You can install it by running: ' .
+                'composer require duncan3dc/fork-helper',
                 get_class($this->client)
             ));
         }
@@ -144,7 +144,13 @@ class ExtendedTest extends Test
             'test-tube-2' => '2',
         ];
 
-        $fork = new \duncan3dc\Helpers\Fork();
+        # Check if we are using Fork1.0 (php < 7)
+        if (class_exists('duncan3dc\Helpers\Fork')) {
+            $fork = new \duncan3dc\Helpers\Fork;
+        } else {
+            $fork = new \duncan3dc\Forker\Fork;
+        }
+
         $fork->call(function () use ($expected) {
             foreach ($expected as $tube => $value) {
                 $this->client->addWorker($tube, function (Job $job) {


### PR DESCRIPTION
I've just released 2.0.0 of the fork-helper, with a few breaking changes, but some big improvements that should help here.

The namespace has changed from `Helpers` to `Forker`, that's mainly what this PR is for.

But 2.0.0 also adds support for the Windows environment, so that you can still use the classes, they just don't do any multi-threading. This should fix #516 while still allowing the semver constraints to be used.

2.0.0 only supports PHP 7.0, so this pr is still a little messy, but when Phalcon drops support for PHP 5.* it can be tidied up considerably.

Here are the new docs for the fork helper: http://duncan3dc.github.io/fork-helper/