### PR TITLE
Updated namespace of duncan3dc

### DIFF
--- a/Library/Phalcon/Queue/Beanstalk/Extended.php
+++ b/Library/Phalcon/Queue/Beanstalk/Extended.php
@@ -19,7 +19,7 @@
 
 namespace Phalcon\Queue\Beanstalk;
 
-use duncan3dc\Helpers\Fork;
+use duncan3dc\Forker\Fork;
 use Phalcon\Logger\Adapter as LoggerAdapter;
 use Phalcon\Queue\Beanstalk as Base;
 


### PR DESCRIPTION
The correct namespace is "duncan3dc\Forker\Fork" instead of "duncan3dc\Helpers\Fork"