### PR TITLE
fix(Http\Client\Provider\Curl)

### DIFF
--- a/Library/Phalcon/Http/Client/Provider/Curl.php
+++ b/Library/Phalcon/Http/Client/Provider/Curl.php
@@ -75,7 +75,7 @@ class Curl extends Request
             CURLOPT_AUTOREFERER     => true,
             CURLOPT_FOLLOWLOCATION  => true,
             CURLOPT_MAXREDIRS       => 20,
-            CURLOPT_HEADER          => true,
+            CURLOPT_HEADER          => false,
             CURLOPT_PROTOCOLS       => CURLPROTO_HTTP | CURLPROTO_HTTPS,
             CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
             CURLOPT_USERAGENT       => 'Phalcon HTTP/' . self::VERSION . ' (Curl)',


### PR DESCRIPTION
CURLOPT_HEADER doesn't need to be set to true when CURLOPT_HEADERFUNCTION is used.