### PR TITLE
fix(Http\Client\Provider\Curl): CURLOPT_HEADER doesn't need to be set…

### DIFF
--- a/Library/Phalcon/Http/Client/Provider/Curl.php
+++ b/Library/Phalcon/Http/Client/Provider/Curl.php
@@ -77,7 +77,7 @@ class Curl extends Request
             CURLOPT_AUTOREFERER     => true,
             CURLOPT_FOLLOWLOCATION  => true,
             CURLOPT_MAXREDIRS       => 20,
-            CURLOPT_HEADER          => true,
+            CURLOPT_HEADER          => false,
             CURLOPT_PROTOCOLS       => CURLPROTO_HTTP | CURLPROTO_HTTPS,
             CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
             CURLOPT_USERAGENT       => 'Phalcon HTTP/' . self::VERSION . ' (Curl)',


### PR DESCRIPTION
… to true when CURLOPT_HEADERFUNCTION is used.

This fixes the recovery of Headers when calling function "send" with $fullResponse = false.
And duplication of Headers when calling function "send" with $fullResponse = true