### PR TITLE
Fixing \Phalcon\Http\Client\Header::addMultiple

### DIFF
--- a/Library/Phalcon/Http/Client/Header.php
+++ b/Library/Phalcon/Http/Client/Header.php
@@ -53,12 +53,25 @@ class Header implements \Countable
     }
 
     /**
-     * @param array $fields
+     * Adds multiple headers.
+     *
+     * <code>
+     * $headers = [
+     *     'X-Foo' => 'bar',
+     *     'Content-Type' => 'application/json',
+     * ];
+     * $curl->addMultiple($headers);
+     * </code>
+     *
+     * @param array $fields An array of name => value pairs.
+     *
      * @return $this
      */
     public function addMultiple(array $fields)
     {
-        $this->fields = array_combine($this->fields, $fields);
+        if (!empty($fields)) {
+            $this->fields = array_merge($this->fields, $fields);
+        }
         return $this;
     }
 


### PR DESCRIPTION
Fixing 

> Warning: array_combine(): Both parameters should have an equal number of elements in /var/www/html/vendor/phalcon/incubator/Library/Phalcon/Http/Client/Header.php on line 61

see issue https://github.com/phalcon/incubator/issues/684