### PR TITLE
Improving usage of parameter 1 "customHeader".

### DIFF
--- a/Library/Phalcon/Http/Client/Provider/Curl.php
+++ b/Library/Phalcon/Http/Client/Provider/Curl.php
@@ -104,7 +104,26 @@ class Curl extends Request
         $this->setOption(CURLOPT_CONNECTTIMEOUT, $timeout);
     }
 
-    protected function send($customHeader = [], $fullResponse = false)
+    /**
+     * Sends the request and returns the response.
+     *
+     * <code>
+     * // using custom headers:
+     * $customHeader = array(
+     *     0 => 'Accept: text/plain',
+     *     1 => 'X-Foo: bar',
+     *     2 => 'X-Bar: baz',
+     * );
+     * $response = $this->send($customHeader);
+     * </code>
+     *
+     * @param array $customHeader An array of values. If not empty then previously added headers gets ignored.
+     * @param bool  $fullResponse If true returns the full response (including headers).
+     *
+     * @return Response
+     * @throws HttpException
+     */
+    protected function send(array $customHeader = [], $fullResponse = false)
     {
         if (!empty($customHeader)) {
             $header = $customHeader;
@@ -113,8 +132,9 @@ class Curl extends Request
             if (count($this->header) > 0) {
                 $header = $this->header->build();
             }
-            $header[] = 'Expect:';
         }
+        $header[] = 'Expect:';
+        $header = array_unique($header, SORT_STRING);
 
         $this->setOption(CURLOPT_HEADERFUNCTION, [$this, 'headerFunction']);
         $this->setOption(CURLOPT_HTTPHEADER, $header);


### PR DESCRIPTION
Parameter 1 `$customHeader` must be type of array (`CURLOPT_HTTPHEADER` expects array).

Try to include `'Expect:`' also in `$customHeader` to get correct response.

Note: providing `$customHeader` without field `'Expect:`' currently messes up the response if the server sends a 100 continue on large request payload. 
F.e. the status code on a 200 OK response would be 100.