### PR TITLE
Fix an issue with double quotes

### DIFF
--- a/Library/Phalcon/Cache/Backend/Aerospike.php
+++ b/Library/Phalcon/Cache/Backend/Aerospike.php
@@ -179,11 +179,7 @@ class Aerospike extends Backend implements BackendInterface
 
         $aKey = $this->buildKey($prefixedKey);
 
-        if (is_numeric($cachedContent)) {
-            $bins = ['value' => $cachedContent];
-        } else {
-            $bins = ['value' => $this->_frontend->beforeStore($cachedContent)];
-        }
+        $bins['value'] = $cachedContent;
 
         $status = $this->db->put(
             $aKey,
@@ -261,11 +257,7 @@ class Aerospike extends Backend implements BackendInterface
 
         $cachedContent = $cache['bins']['value'];
 
-        if (is_numeric($cachedContent)) {
-            return $cachedContent;
-        }
-
-        return $this->_frontend->afterRetrieve($cachedContent);
+        return $cachedContent;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "sgenov/incubator",
+    "name": "phalcon/incubator",
     "type": "library",
     "description": "Adapters, prototypes or functionality that can be potentially incorporated to the C-framework.",
     "keywords": ["framework", "phalcon", "incubator"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "phalcon/incubator",
+    "name": "sgenov/incubator",
     "type": "library",
     "description": "Adapters, prototypes or functionality that can be potentially incorporated to the C-framework.",
     "keywords": ["framework", "phalcon", "incubator"],

--- a/tests/unit/Cache/Backend/AerospikeTest.php
+++ b/tests/unit/Cache/Backend/AerospikeTest.php
@@ -121,11 +121,11 @@ class AerospikeTest extends Test
 
         $data = [1, 2, 3, 4, 5];
         $cache->save('test-data', $data);
-        $this->tester->seeInAerospike('test-data', serialize($data));
+        $this->tester->seeInAerospike('test-data', $data);
 
         $data = "sure, nothing interesting";
         $cache->save('test-data', $data);
-        $this->tester->seeInAerospike('test-data', serialize($data));
+        $this->tester->seeInAerospike('test-data', $data);
     }
 
     public function testShouldDeleteData()

--- a/tests/unit/Session/Adapter/AerospikeTest.php
+++ b/tests/unit/Session/Adapter/AerospikeTest.php
@@ -72,7 +72,7 @@ class AerospikeTest extends Test
             ];
 
         $this->assertTrue($session->write($sessionId, $data));
-        $this->tester->seeInAerospike($sessionId, serialize($data));
+        $this->tester->seeInAerospike($sessionId, $data);
     }
 
     public function testShouldReadSession()
@@ -86,7 +86,7 @@ class AerospikeTest extends Test
                 'xyz' => 'zyx'
             ];
 
-        $this->tester->haveInAerospike($sessionId, serialize($data));
+        $this->tester->haveInAerospike($sessionId, $data);
         $this->keys[] = $sessionId;
 
         $this->assertEquals($data, $session->read($sessionId));
@@ -103,7 +103,7 @@ class AerospikeTest extends Test
                 'zyx' => 'xyz'
             ];
 
-        $this->tester->haveInAerospike($sessionId, serialize($data));
+        $this->tester->haveInAerospike($sessionId, $data);
         $session->destroy($sessionId);
         $this->tester->dontSeeInAerospike($sessionId);
     }

--- a/tests/unit/Session/Adapter/AerospikeTest.php
+++ b/tests/unit/Session/Adapter/AerospikeTest.php
@@ -65,13 +65,11 @@ class AerospikeTest extends Test
         $sessionId = 'abcdef123458';
         $session = new SessionHandler($this->getConfig());
 
-        $data = serialize(
-            [
+        $data = [
                 321   => microtime(true),
                 'def' => '678',
                 'xyz' => 'zyx'
-            ]
-        );
+            ];
 
         $this->assertTrue($session->write($sessionId, $data));
         $this->tester->seeInAerospike($sessionId, serialize($data));
@@ -82,13 +80,11 @@ class AerospikeTest extends Test
         $sessionId = 'some_session_key';
         $session = new SessionHandler($this->getConfig());
 
-        $data = serialize(
-            [
+        $data = [
                 321   => microtime(true),
                 'def' => '678',
                 'xyz' => 'zyx'
-            ]
-        );
+            ];
 
         $this->tester->haveInAerospike($sessionId, serialize($data));
         $this->keys[] = $sessionId;
@@ -101,13 +97,11 @@ class AerospikeTest extends Test
         $sessionId = 'abcdef123457';
         $session = new SessionHandler($this->getConfig());
 
-        $data = serialize(
-            [
+        $data = [
                 'abc' => 345,
                 'def' => ['foo' => 'bar'],
                 'zyx' => 'xyz'
-            ]
-        );
+            ];
 
         $this->tester->haveInAerospike($sessionId, serialize($data));
         $session->destroy($sessionId);


### PR DESCRIPTION
The storage type of the field is Bin, which means it does not need to be serialized. This simplifies things and saves a few CPU clicks.
Also, I just encountered an issue with serializing - the double quotes in the strings are understood as "end of the string" and so it is cut to the first double quote.