### PR TITLE
Adding a flush() method for aerospike's backend cache

### DIFF
--- a/Library/Phalcon/Cache/Backend/Aerospike.php
+++ b/Library/Phalcon/Cache/Backend/Aerospike.php
@@ -282,13 +282,16 @@ class Aerospike extends Backend implements BackendInterface
      *
      * @return boolean
      */
-    public function flush() {
+    public function flush()
+    {
         $keys = $this->queryKeys();
 
         $success = true;
 
         foreach($keys as $aKey) {
-            if (!$this->delete($aKey)) $success = false;
+            if (!$this->delete($aKey)) {
+             $success = false;
+            }
         }
 
         return $success;

--- a/Library/Phalcon/Cache/Backend/Aerospike.php
+++ b/Library/Phalcon/Cache/Backend/Aerospike.php
@@ -283,8 +283,6 @@ class Aerospike extends Backend implements BackendInterface
      * @return boolean
      */
     public function flush() {
-        $kyes = [];
-
         $keys = $this->queryKeys();
 
         $success = true;

--- a/Library/Phalcon/Cache/Backend/Aerospike.php
+++ b/Library/Phalcon/Cache/Backend/Aerospike.php
@@ -276,6 +276,25 @@ class Aerospike extends Backend implements BackendInterface
 
         return $status == \Aerospike::OK;
     }
+ 
+    /**
+     * {@inheritdoc}
+     *
+     * @return boolean
+     */
+    public function flush() {
+        $kyes = [];
+
+        $keys = $this->queryKeys();
+
+        $success = true;
+
+        foreach($keys as $aKey) {
+            if (!$this->delete($aKey)) $success = false;
+        }
+
+        return $success;
+    }
 
     /**
      * {@inheritdoc}

--- a/Library/Phalcon/Cache/Backend/Aerospike.php
+++ b/Library/Phalcon/Cache/Backend/Aerospike.php
@@ -290,7 +290,7 @@ class Aerospike extends Backend implements BackendInterface
 
         foreach ($keys as $aKey) {
             if (!$this->delete($aKey)) {
-             $success = false;
+                $success = false;
             }
         }
 

--- a/Library/Phalcon/Cache/Backend/Aerospike.php
+++ b/Library/Phalcon/Cache/Backend/Aerospike.php
@@ -288,7 +288,7 @@ class Aerospike extends Backend implements BackendInterface
 
         $success = true;
 
-        foreach($keys as $aKey) {
+        foreach ($keys as $aKey) {
             if (!$this->delete($aKey)) {
              $success = false;
             }

--- a/tests/unit/Cache/Backend/AerospikeTest.php
+++ b/tests/unit/Cache/Backend/AerospikeTest.php
@@ -139,6 +139,22 @@ class AerospikeTest extends Test
         $this->assertTrue($cache->delete('test-data'));
         $this->tester->dontSeeInAerospike('test-data');
     }
+    
+    public function testShouldFlushAllData()
+    {
+        $cache = $this->getAdapter();
+        $this->keys[] = 'test-data-flush';
+        $this->keys[] = 'test-data-flush2';
+        
+        $data = "sure, nothing interesting";
+        $cache->save('test-data-flush', $data);
+        $cache->save('test-data-flush2', $data);
+        
+        $cache->flush();
+        
+        $this->tester->dontSeeInAerospike('test-data-flush');
+        $this->tester->dontSeeInAerospike('test-data-flush2');
+    }
 
     public function testShouldUseOutputFrontend()
     {


### PR DESCRIPTION
Hello!

* Type: new feature

This pull request affects the following components: **(please check boxes)**

* [x] Library
* [ ] Code Style
* [ ] Documentation
* [ ] Testing

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/incubator/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Phalcon has a method for clearing the cache. That method requires a flush() method inside the cache's class. I added that method.

Thanks
