### PR TITLE
Added flush method to Aerospike

### DIFF
--- a/Library/Phalcon/Cache/Backend/Aerospike.php
+++ b/Library/Phalcon/Cache/Backend/Aerospike.php
@@ -280,6 +280,26 @@ class Aerospike extends Backend implements BackendInterface
     /**
      * {@inheritdoc}
      *
+     * @return boolean
+     */
+    public function flush()
+    {
+        $keys = $this->queryKeys();
+
+        $success = true;
+
+        foreach ($keys as $aKey) {
+            if (!$this->delete($aKey)) {
+                $success = false;
+            }
+        }
+
+        return $success;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @param string $keyName
      * @param int    $lifetime
      * @return boolean

--- a/tests/unit/Cache/Backend/AerospikeTest.php
+++ b/tests/unit/Cache/Backend/AerospikeTest.php
@@ -94,10 +94,20 @@ class AerospikeTest extends Test
 
         $this->assertEquals(['a', 'bcd', 'long-key'], $keys);
         $this->assertEquals(['long-key'], $cache->queryKeys('long'));
+    }
 
-        $cache->delete('a');
-        $cache->delete('long-key');
-        $cache->delete('bcd');
+    public function testShouldFlushAllData()
+    {
+        $cache = $this->getAdapter();
+
+        $data = "sure, nothing interesting";
+        $cache->save('test-data-flush', $data);
+        $cache->save('test-data-flush2', $data);
+
+        $cache->flush();
+
+        $this->tester->dontSeeInAerospike('test-data-flush');
+        $this->tester->dontSeeInAerospike('test-data-flush2');
     }
 
     public function testShouldSaveData()


### PR DESCRIPTION
Hello!

* Type: new feature 

This pull request affects the following components: 

* [x] Library
* [ ] Code Style
* [ ] Documentation
* [ ] Testing

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/incubator/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Phalcon has a method for clearing the cache. That method requires a flush() method inside the cache's class. I added that method.

Thanks

