### PR TITLE
Added Mongo translation adapter to work with collections.

### DIFF
--- a/Library/Phalcon/Translate/Adapter/Mongo.php
+++ b/Library/Phalcon/Translate/Adapter/Mongo.php
@@ -1,0 +1,218 @@
+<?php
+
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Framework                                                      |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2016 Phalcon Team (https://www.phalconphp.com)      |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file LICENSE.txt.                             |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Gorka Guridi <gorka.guridi@gmail.com>                         |
+  +------------------------------------------------------------------------+
+*/
+
+namespace Phalcon\Translate\Adapter;
+
+use Phalcon\Translate\Exception;
+use Phalcon\Mvc\CollectionInterface;
+use Phalcon\Translate\AdapterInterface;
+
+/**
+ * Phalcon\Translate\Adapter\Mongo
+ *
+ * Implements a mongo adapter for translations.
+ *
+ * A generic collection with a source to store the translations must be created
+ * and passed as a parameter.
+ *
+ * @package Phalcon\Translate\Adapter
+ */
+class Mongo extends Base implements AdapterInterface, \ArrayAccess
+{
+    protected $language;
+    protected $collection;
+    protected $formatter;
+
+    /**
+     * Mongo constructor.
+     *
+     * @param array $options
+     *
+     * @throws Exception
+     */
+    public function __construct($options)
+    {
+        if (!isset($options['collection'])) {
+            throw new Exception("Parameter 'collection' is required");
+        }
+
+        $this->setCollection($options['collection']);
+
+        if (!isset($options['language'])) {
+            throw new Exception("Parameter 'language' is required");
+        }
+
+        $this->setLanguage($options['language']);
+
+        if (isset($options['formatter'])) {
+            $this->setFormatter($options['formatter']);
+        }
+    }
+
+    /**
+     * Sets the collection object.
+     *
+     * @param CollectionInterface|string $collection Translations collection class to use.
+     *                                               Can be an instance of CollectionInterface or a string.
+     */
+    protected function setCollection($collection)
+    {
+        $this->collection = $collection;
+    }
+
+    /**
+     * Sets the language to use.
+     *
+     * @param string $language
+     */
+    protected function setLanguage($language)
+    {
+        $this->language = $language;
+    }
+
+    /**
+     * Sets the formatter to use if necessary.
+     *
+     * @param \MessageFormatter $formatter Message formatter.
+     */
+    protected function setFormatter(\MessageFormatter $formatter)
+    {
+        $this->formatter = $formatter;
+    }
+
+    /**
+     * Gets the translations set.
+     *
+     * @param string $translateKey
+     *   Key of the collection set.
+     *
+     * @return mixed
+     */
+    protected function getTranslations($translateKey)
+    {
+        /** @var CollectionInterface $collection */
+        $collection = $this->collection;
+
+        return $collection::findFirst([['key' => $translateKey]]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function _($translateKey, $placeholders = null)
+    {
+        return $this->query($translateKey, $placeholders);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function query($translateKey, $placeholders = null)
+    {
+        $translations = $this->getTranslations($translateKey);
+        $translation = $translateKey;
+
+        if (isset($translations->{$this->language})) {
+            $translation = $translations->{$this->language};
+        }
+
+        if (!empty($placeholders)) {
+            return $this->format($translation, $placeholders);
+        }
+
+        return $translation;
+    }
+
+    /**
+     * Formats a translation.
+     *
+     * @param string $translation  Translated text.
+     * @param array  $placeholders Placeholders to apply.
+     *
+     * @return string
+     */
+    protected function format($translation, $placeholders = [])
+    {
+        if ($this->formatter) {
+            $formatter = $this->formatter;
+
+            return $formatter::formatMessage($this->language, $translation, $placeholders);
+        }
+
+        foreach ($placeholders as $key => $value) {
+            $translation = str_replace("%$key%", $value, $translation);
+        }
+
+        return $translation;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function exists($translateKey)
+    {
+        $translations = $this->getTranslations($translateKey);
+
+        return isset($translations->{$this->language});
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetExists($translateKey)
+    {
+        return $this->exists($translateKey);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetSet($translateKey, $message)
+    {
+        $translations = $this->getTranslations($translateKey);
+        $translations->{$this->language} = $message;
+
+        return $translations->save();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetGet($translateKey)
+    {
+        $translations = $this->getTranslations($translateKey);
+
+        if (isset($translations->{$this->language})) {
+            return $translations->{$this->language};
+        }
+
+        return '';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetUnset($translateKey)
+    {
+        $translations = $this->getTranslations($translateKey);
+        unset($translations->{$this->language});
+
+        return $translations->save();
+    }
+}

--- a/Library/Phalcon/Translate/Adapter/README.md
+++ b/Library/Phalcon/Translate/Adapter/README.md
@@ -9,28 +9,28 @@ You can use your database to store the translations, too.
 First of all, you need to up your database. To do this, use [DI][1] (in `/public/index.php`). Take a look:
 
 ```php
-// ...
+use Phalcon\Db\Adapter\Pdo\Mysql;
 
 $di->set('db', function() {
-	return new \Phalcon\Db\Adapter\Pdo\Mysql([
+	return new Mysql([
 		'host'     => 'localhost',
 		'username' => 'root',
 		'password' => 123456,
 		'dbname'   => 'application'
 	]);
 });
-
-// ...
 ```
 
 Then, you should get the translation through your `controller`. Put this on it:
 
 ```php
+use Phalcon\Translate\Adapter\Database;
+
 class IndexController extends \Phalcon\Mvc\Controller
 {
 	protected function _getTranslation()
 	{
-		return new Phalcon\Translate\Adapter\Database([
+		return new Database([
 		    'db'                     => $this->di->get('db'), // Here we're getting the database from DI
 		    'table'                  => 'translations', // The table that is storing the translations
 		    'language'               => $this->request->getBestLanguage(), // Now we're getting the best language for the user
@@ -82,7 +82,7 @@ class IndexController extends \Phalcon\Mvc\Controller
 
 Then, just output the`phrase/sentence/word` in your view:
 
-```html+php
+```php
 <html>
 	<head>
 		<!-- ... -->
@@ -94,7 +94,7 @@ Then, just output the`phrase/sentence/word` in your view:
 ```
 
 Or, if you wish you can use [Volt][2]:
-```html+php
+```php
 <h1>{{ expression._("IndexPage_Hello_World") }}</h1>
 ```
 
@@ -106,6 +106,32 @@ ICU MessageFormatter Example
 $this->_getTranslation()->_('cats', ['nbCats' => rand(0, 10)]);
 ```
 
+## Mongo
+
+Implements a Mongo adapter for translations.
+
+A generic collection with a source to store the translations must be created and passed as a parameter.
+
+```php
+use MessageFormatter;
+use Phalcon\Translate\Adapter\Mongo;
+use My\Application\Collections\Translate;
+
+$fmt = new MessageFormatter(
+    "en_US",
+    "{0,number,integer} monkeys on {1,number,integer} trees make {2,number} monkeys per tree"
+);
+
+$translate = new Mongo([
+    'collection' => Translate::class,
+    'language'   => 'en',
+    'formatter'  => $fmt,
+]);
+
+echo $translate->t('application.title');
+```
+
+
 ## ResourceBundle
 
 This adapter uses ResourceBundle as translation frontend.
@@ -113,7 +139,9 @@ This adapter uses ResourceBundle as translation frontend.
 The extension [intl][3] must be installed in PHP.
 
 ```php
-$translate = new Phalcon\Translate\Adapter\ResourceBundle([
+use Phalcon\Translate\Adapter\ResourceBundle;
+
+$translate = new ResourceBundle([
     'bundle'   => '/path/to/bundle', // required
     'locale'   => 'en',              // required
     'fallback' => false              // optional, default - true

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ### Translate
 * [Phalcon\Translate\Adapter\Database](Library/Phalcon/Translate/Adapter) - Translation adapter using relational databases (@phalcon)
+* [Phalcon\Translate\Adapter\Mongo](Library/Phalcon/Translate/Adapter) - Implements a Mongo adapter for translations (@gguridi)
 * [Phalcon\Translate\Adapter\ResourceBundle](Library/Phalcon/Translate/Adapter) - Translation adapter using ResourceBundle (@phalcon)
 
 ### Session


### PR DESCRIPTION
Hello!

* Type: new feature
* Refs: https://github.com/phalcon/incubator/pull/701

This pull request affects the following components:

* [x] Library
* [ ] Code Style
* [ ] Documentation
* [ ] Testing

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/incubator/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Added a translation adapter to work with mongo databases. It requires the creation of a collection to store the translations and the adapter does the rest.

I've not created tests because I've not seen other tests for the translation adapters and I'm not sure if they are strictly necessary.

Thanks

