### PR TITLE
replacing preg_match with a strpos. lighter weight.

### DIFF
--- a/Library/Phalcon/Http/Client/Provider/Curl.php
+++ b/Library/Phalcon/Http/Client/Provider/Curl.php
@@ -175,7 +175,7 @@ class Curl extends Request
     {
         if (is_array($params)) {
             foreach ($params as $param) {
-                if (is_string($param) && preg_match('/^@/', $param)) {
+                if (is_string($param) && strpos($param, '@') === 0) {
                     $useEncoding = false;
                     break;
                 }


### PR DESCRIPTION
Hello!

* Type: code quality
* Link to issue: (nothing posted)

This pull request affects the following components: **(please check boxes)**

* [X] Library
* [ ] Code Style
* [ ] Documentation
* [ ] Testing

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/incubator/blob/master/CONTRIBUTING.md)?
- [X] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:
The check using preg seemed excessive. A strpos is equivalent and much more lightweight.
This is a [requested](https://github.com/phalcon/incubator/pull/714#issuecomment-266674323) PR to the 3.0.x branch, based on an [already merged PR](https://github.com/phalcon/incubator/pull/714) to the 2.0.x branch.

Thanks

