### PR TITLE
Adding Helper To Mock Result Sets In Testing

### DIFF
--- a/Library/Phalcon/Test/Traits/ResultSet.php
+++ b/Library/Phalcon/Test/Traits/ResultSet.php
@@ -18,6 +18,7 @@
 */
 
 namespace Phalcon\Test\Traits;
+
 use Phalcon\Mvc\Model\Resultset;
 
 /**

--- a/Library/Phalcon/Test/Traits/ResultSet.php
+++ b/Library/Phalcon/Test/Traits/ResultSet.php
@@ -59,13 +59,6 @@ trait ResultSet
         $sharedData->pos = 0;
         $sharedData->data = $dataSet;
 
-        $mockResultSet->method('rewind')
-            ->willReturnCallback(
-                function() use ($sharedData) {
-                    $sharedData->pos = 0;
-                }
-            );
-
         $mockResultSet->method('getFirst')
             ->willReturnCallback(function() use ($sharedData) {
                 if (empty($sharedData->data)) {

--- a/Library/Phalcon/Test/Traits/ResultSet.php
+++ b/Library/Phalcon/Test/Traits/ResultSet.php
@@ -18,6 +18,7 @@
 */
 
 namespace Phalcon\Test\Traits;
+use Phalcon\Mvc\Model\Resultset;
 
 /**
  * Trait ResultSet. Adds Ability To Mock DB ResultSet (Without Actual Connection To DB)
@@ -34,7 +35,7 @@ trait ResultSet
      *
      * @return \PHPUnit_Framework_MockObject_MockObject|\Phalcon\Mvc\Model\Resultset|\Phalcon\Mvc\Model\ResultsetInterface
      */
-    public function mockResultSet(array $dataSet, $className = '\Phalcon\Mvc\Model\Resultset')
+    public function mockResultSet(array $dataSet, $className = Resultset::class)
     {
         /** @var \PHPUnit_Framework_TestCase $this */
         /** @var \PHPUnit_Framework_MockObject_MockObject $mockResultSet */

--- a/Library/Phalcon/Test/Traits/ResultSet.php
+++ b/Library/Phalcon/Test/Traits/ResultSet.php
@@ -19,7 +19,7 @@
 
 namespace Phalcon\Test\Traits;
 
-use Phalcon\Mvc\Model\Resultset;
+use Phalcon\Mvc\Model\Resultset as phResultset;
 
 /**
  * Trait ResultSet. Adds Ability To Mock DB ResultSet (Without Actual Connection To DB)
@@ -36,7 +36,7 @@ trait ResultSet
      *
      * @return \PHPUnit_Framework_MockObject_MockObject|\Phalcon\Mvc\Model\Resultset|\Phalcon\Mvc\Model\ResultsetInterface
      */
-    public function mockResultSet(array $dataSet, $className = Resultset::class)
+    public function mockResultSet(array $dataSet, $className = phResultset::class)
     {
         /** @var \PHPUnit_Framework_TestCase $this */
         /** @var \PHPUnit_Framework_MockObject_MockObject $mockResultSet */

--- a/Library/Phalcon/Test/Traits/ResultSet.php
+++ b/Library/Phalcon/Test/Traits/ResultSet.php
@@ -43,17 +43,17 @@ trait ResultSet
         $mockResultSet = $this->getMockBuilder($className)
             ->disableOriginalConstructor()
             ->setMethods(
-              [
-                'valid', 
-                'current', 
-                'key', 
-                'next', 
-                'toArray', 
-                'getFirst', 
-                'getLast', 
-                'serialize', 
-                'unserialize'
-              ]
+                [
+                    'valid',
+                    'current',
+                    'key',
+                    'next',
+                    'toArray',
+                    'getFirst',
+                    'getLast',
+                    'serialize',
+                    'unserialize'
+                ]
             )->getMockForAbstractClass();
 
         //Work Around For Final Count Method

--- a/Library/Phalcon/Test/Traits/ResultSet.php
+++ b/Library/Phalcon/Test/Traits/ResultSet.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Framework                                                      |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2016 Phalcon Team (https://www.phalconphp.com)      |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file LICENSE.txt.                             |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Phoenix Osiris <phoenix@twistersfury.com>                     |
+  +------------------------------------------------------------------------+
+*/
+
+namespace Phalcon\Test\Traits;
+
+/**
+ * Trait ResultSet. Adds Ability To Mock DB ResultSet (Without Actual Connection To DB)
+ *
+ * The resulting mock is only intended to mock the basic functions of a resultset.
+ *
+ * @package Phalcon\Test\Traits
+ */
+trait ResultSet
+{
+    /**
+     * @param array $dataSet Mock Data Set To Use
+     * @param string $className ResultSet Class To Mimic (Defaults To Abstract ResultSet)
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|\Phalcon\Mvc\Model\Resultset|\Phalcon\Mvc\Model\ResultsetInterface
+     */
+    public function mockResultSet(array $dataSet, $className = '\Phalcon\Mvc\Model\Resultset')
+    {
+        /** @var \PHPUnit_Framework_TestCase $this */
+        /** @var \PHPUnit_Framework_MockObject_MockObject $mockResultSet */
+
+
+        $mockResultSet = $this->getMockBuilder($className)
+            ->disableOriginalConstructor()
+            ->setMethods(['valid', 'current', 'key', 'next', 'toArray', 'getFirst', 'getLast', 'serialize', 'unserialize'])
+            ->getMockForAbstractClass();
+
+        //Work Around For Final Count Method
+        $reflectionMethod = new \ReflectionProperty('\Phalcon\Mvc\Model\Resultset', '_count');
+        $reflectionMethod->setAccessible(true);
+        $reflectionMethod->setValue($mockResultSet, count($dataSet));
+
+        //Work Around For Final Seek
+        $reflectionProperty = new \ReflectionProperty('\Phalcon\Mvc\Model\Resultset', '_rows');
+        $reflectionProperty->setAccessible(TRUE);
+        $reflectionProperty->setValue($mockResultSet, $dataSet);
+
+        $sharedData = new \stdClass();
+        $sharedData->pos = 0;
+        $sharedData->data = $dataSet;
+
+        $mockResultSet->method('rewind')
+            ->willReturnCallback(
+                function() use ($sharedData) {
+                    $sharedData->pos = 0;
+                }
+            );
+
+        $mockResultSet->method('getFirst')
+            ->willReturnCallback(function() use ($sharedData) {
+                if (empty($sharedData->data)) {
+                    return false;
+                }
+
+                $arrayKeys = array_keys($sharedData->data);
+                return $sharedData->data[$arrayKeys[0]];
+            });
+
+        $mockResultSet->method('getLast')
+            ->willReturnCallback(function()  use ($sharedData) {
+                if (empty($sharedData->data)) {
+                    return false;
+                }
+
+                return array_reverse($sharedData->data)[0];
+            });
+
+        $mockResultSet->method('valid')
+            ->willReturnCallback(
+                function() use ($sharedData) {
+                    return $sharedData->pos < count($sharedData->data);
+                }
+            );
+
+        $mockResultSet->method('current')
+            ->willReturnCallback(
+                function() use ($sharedData) {
+                    return $sharedData->data[$sharedData->pos];
+                }
+            );
+
+        $mockResultSet->method('key')
+            ->willReturnCallback(
+                function() use($sharedData) {
+                    return array_keys($sharedData->data)[$sharedData->pos];
+                }
+            );
+
+        $mockResultSet->method('next')
+            ->willReturnCallback(
+                function() use ($sharedData) {
+                    $sharedData->pos++;
+                }
+            );
+
+        $mockResultSet->method('toArray')
+            ->willReturn($dataSet);
+
+        return $mockResultSet;
+    }
+}

--- a/Library/Phalcon/Test/Traits/ResultSet.php
+++ b/Library/Phalcon/Test/Traits/ResultSet.php
@@ -42,8 +42,19 @@ trait ResultSet
 
         $mockResultSet = $this->getMockBuilder($className)
             ->disableOriginalConstructor()
-            ->setMethods(['valid', 'current', 'key', 'next', 'toArray', 'getFirst', 'getLast', 'serialize', 'unserialize'])
-            ->getMockForAbstractClass();
+            ->setMethods(
+              [
+                'valid', 
+                'current', 
+                'key', 
+                'next', 
+                'toArray', 
+                'getFirst', 
+                'getLast', 
+                'serialize', 
+                'unserialize'
+              ]
+            )->getMockForAbstractClass();
 
         //Work Around For Final Count Method
         $reflectionMethod = new \ReflectionProperty('\Phalcon\Mvc\Model\Resultset', '_count');
@@ -52,7 +63,7 @@ trait ResultSet
 
         //Work Around For Final Seek
         $reflectionProperty = new \ReflectionProperty('\Phalcon\Mvc\Model\Resultset', '_rows');
-        $reflectionProperty->setAccessible(TRUE);
+        $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($mockResultSet, $dataSet);
 
         $sharedData = new \stdClass();
@@ -60,7 +71,7 @@ trait ResultSet
         $sharedData->data = $dataSet;
 
         $mockResultSet->method('getFirst')
-            ->willReturnCallback(function() use ($sharedData) {
+            ->willReturnCallback(function () use ($sharedData) {
                 if (empty($sharedData->data)) {
                     return false;
                 }
@@ -70,7 +81,7 @@ trait ResultSet
             });
 
         $mockResultSet->method('getLast')
-            ->willReturnCallback(function()  use ($sharedData) {
+            ->willReturnCallback(function ()  use ($sharedData) {
                 if (empty($sharedData->data)) {
                     return false;
                 }
@@ -80,28 +91,28 @@ trait ResultSet
 
         $mockResultSet->method('valid')
             ->willReturnCallback(
-                function() use ($sharedData) {
+                function () use ($sharedData) {
                     return $sharedData->pos < count($sharedData->data);
                 }
             );
 
         $mockResultSet->method('current')
             ->willReturnCallback(
-                function() use ($sharedData) {
+                function () use ($sharedData) {
                     return $sharedData->data[$sharedData->pos];
                 }
             );
 
         $mockResultSet->method('key')
             ->willReturnCallback(
-                function() use($sharedData) {
+                function () use($sharedData) {
                     return array_keys($sharedData->data)[$sharedData->pos];
                 }
             );
 
         $mockResultSet->method('next')
             ->willReturnCallback(
-                function() use ($sharedData) {
+                function () use ($sharedData) {
                     $sharedData->pos++;
                 }
             );

--- a/Library/Phalcon/Test/Traits/ResultSet.php
+++ b/Library/Phalcon/Test/Traits/ResultSet.php
@@ -81,7 +81,7 @@ trait ResultSet
             });
 
         $mockResultSet->method('getLast')
-            ->willReturnCallback(function ()  use ($sharedData) {
+            ->willReturnCallback(function () use ($sharedData) {
                 if (empty($sharedData->data)) {
                     return false;
                 }
@@ -105,7 +105,7 @@ trait ResultSet
 
         $mockResultSet->method('key')
             ->willReturnCallback(
-                function () use($sharedData) {
+                function () use ($sharedData) {
                     return array_keys($sharedData->data)[$sharedData->pos];
                 }
             );

--- a/Library/Phalcon/Test/UnitTestCase.php
+++ b/Library/Phalcon/Test/UnitTestCase.php
@@ -21,6 +21,7 @@ namespace Phalcon\Test;
 
 use Phalcon\Di\InjectionAwareInterface;
 use PHPUnit\Framework\TestCase as TestCase;
+use Phalcon\Test\Traits\ResultSet;
 use Phalcon\Config;
 use Phalcon\Di\FactoryDefault;
 use Phalcon\Di;
@@ -35,6 +36,8 @@ use Phalcon\Escaper;
  */
 abstract class UnitTestCase extends TestCase implements InjectionAwareInterface
 {
+    use ResultSet;
+
     /**
      * Holds the configuration variables and other stuff
      * I can use the DI container but for tests like the Translate

--- a/tests/unit/Session/Adapter/AerospikeTest.php
+++ b/tests/unit/Session/Adapter/AerospikeTest.php
@@ -57,7 +57,9 @@ class AerospikeTest extends Test
      */
     protected function _after()
     {
-        $this->cleanup();
+        if (extension_loaded('aerospike')) {
+            $this->cleanup();
+        }
     }
 
     public function testShouldWriteSession()

--- a/tests/unit/Test/Traits/ResultSetTest.php
+++ b/tests/unit/Test/Traits/ResultSetTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Phalcon\Test\Test\Traits;
 
+use Phalcon\Mvc\Model;
+use Phalcon\Mvc\Model\Resultset\Simple;
 use Phalcon\Test\Traits\ResultSet;
 use Codeception\TestCase\Test;
 
@@ -26,24 +28,24 @@ class ResultSetTest extends Test
     use ResultSet;
 
     /** @var \Phalcon\Test\Traits\ResultSet  */
-    protected $testSubject = NULL;
+    protected $testSubject = null;
 
     public function setUp() {
         $this->testSubject = $this;
     }
 
     public function testCanMockResultSet() {
-        $mockModel = $this->getMockBuilder('\Phalcon\Mvc\Model')
+        $mockModel = $this->getMockBuilder(Model::class)
             ->setMockClassName('ClassA')
             ->disableOriginalConstructor()
             ->getMock();
 
-        $mockSecondModel = $this->getMockBuilder('\Phalcon\Mvc\Model')
+        $mockSecondModel = $this->getMockBuilder(Model::class)
             ->setMockClassName('ClassB')
             ->disableOriginalConstructor()
             ->getMock();
 
-        $mockThirdModel = $this->getMockBuilder('\Phalcon\Mvc\Model')
+        $mockThirdModel = $this->getMockBuilder(Model::class)
             ->setMockClassName('ClassC')
             ->disableOriginalConstructor()
             ->getMock();
@@ -75,7 +77,8 @@ class ResultSetTest extends Test
         $this->assertSame($mockData, $mockResultSet->toArray());
     }
 
-    public function testCanMockEmptyResultSet() {
+    public function testCanMockEmptyResultSet()
+    {
         /** @var \Phalcon\Mvc\Model\Resultset $mockResultSet */
         $mockResultSet = $this->testSubject->mockResultset([]);
 
@@ -84,8 +87,9 @@ class ResultSetTest extends Test
         $this->assertFalse($mockResultSet->getLast());
     }
 
-    public function testCanUseOtherResultSetClasses() {
-        $mockResultset = $this->mockResultset([], '\Phalcon\Mvc\Model\Resultset\Simple');
-        $this->assertInstanceOf('\Phalcon\Mvc\Model\Resultset\Simple', $mockResultset);
+    public function testCanUseOtherResultSetClasses()
+    {
+        $mockResultset = $this->mockResultset([], Simple::class);
+        $this->assertInstanceOf(Simple::class, $mockResultset);
     }
 }

--- a/tests/unit/Test/Traits/ResultSetTest.php
+++ b/tests/unit/Test/Traits/ResultSetTest.php
@@ -1,16 +1,26 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: Charles.Martin
- * Date: 12/13/2016
- * Time: 12:41 PM
- */
-
-namespace unit\Test\Traits;
+namespace Phalcon\Test\Test\Traits;
 
 use Phalcon\Test\Traits\ResultSet;
 use Codeception\TestCase\Test;
 
+/**
+ * \Phalcon\Test\Test\Traits\ResultSetTest
+ * Tests for Phalcon\Test\Traits\ResultSet component
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Phoenix Osiris <phoenix@twistersfury.com>
+ * @package   Phalcon\Test\Test\Traits
+ * @group     Acl
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
 class ResultSetTest extends Test
 {
     use ResultSet;

--- a/tests/unit/Test/Traits/ResultSetTest.php
+++ b/tests/unit/Test/Traits/ResultSetTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Charles.Martin
+ * Date: 12/13/2016
+ * Time: 12:41 PM
+ */
+
+namespace unit\Test\Traits;
+
+use Phalcon\Test\Traits\ResultSet;
+use Codeception\TestCase\Test;
+
+class ResultSetTest extends Test
+{
+    use ResultSet;
+
+    /** @var \Phalcon\Test\Traits\ResultSet  */
+    protected $testSubject = NULL;
+
+    public function setUp() {
+        $this->testSubject = $this;
+    }
+
+    public function testCanMockResultSet() {
+        $mockModel = $this->getMockBuilder('\Phalcon\Mvc\Model')
+            ->setMockClassName('ClassA')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockSecondModel = $this->getMockBuilder('\Phalcon\Mvc\Model')
+            ->setMockClassName('ClassB')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockThirdModel = $this->getMockBuilder('\Phalcon\Mvc\Model')
+            ->setMockClassName('ClassC')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockData = [
+            $mockModel,
+            $mockSecondModel,
+            $mockThirdModel,
+        ];
+
+        /** @var \Phalcon\Mvc\Model\Resultset $mockResultSet */
+        $mockResultSet = $this->testSubject->mockResultSet($mockData);
+
+        //Testing Count
+        $this->assertEquals(3, $mockResultSet->count());
+
+        //Testing Rewind/Valid/Current/Key/Next
+        foreach($mockResultSet as $currentKey => $testModel) {
+            $this->assertSame($mockData[$currentKey], $testModel);
+        }
+
+        //Testing getFirst
+        $this->assertSame($mockModel, $mockResultSet->getFirst());
+
+        //Testing getLast
+        $this->assertSame($mockThirdModel, $mockResultSet->getLast());
+
+        //Testing toArray
+        $this->assertSame($mockData, $mockResultSet->toArray());
+    }
+
+    public function testCanMockEmptyResultSet() {
+        /** @var \Phalcon\Mvc\Model\Resultset $mockResultSet */
+        $mockResultSet = $this->testSubject->mockResultset([]);
+
+        $this->assertEquals(0, $mockResultSet->count());
+        $this->assertFalse($mockResultSet->getFirst());
+        $this->assertFalse($mockResultSet->getLast());
+    }
+
+    public function testCanUseOtherResultSetClasses() {
+        $mockResultset = $this->mockResultset([], '\Phalcon\Mvc\Model\Resultset\Simple');
+        $this->assertInstanceOf('\Phalcon\Mvc\Model\Resultset\Simple', $mockResultset);
+    }
+}


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: NA

This pull request affects the following components: **(please check boxes)**

* [ ] Library
* [ ] Code Style
* [ ] Documentation
* [x] Testing

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/incubator/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

I've added a trait for mocking a basic Result set. This comes in handy when doing unit tests and I don't want to have to actually connect to the DB to do so. 

Thanks
