### PR TITLE
Curl::initPostFields checks for \CURLFile

### DIFF
--- a/Library/Phalcon/Http/Client/Provider/Curl.php
+++ b/Library/Phalcon/Http/Client/Provider/Curl.php
@@ -199,15 +199,14 @@ class Curl extends Request
             ? '\CURLFile'
             : null;
         foreach ($params as $value) {
-            if (
-                (is_string($value) && strpos($value, '@') === 0)
+            if ((is_string($value) && strpos($value, '@') === 0)
                 || ($classCurlFile && $value instanceof $classCurlFile)
             ) {
                 return false;
             }
         }
         return true;
-    } 
+    }
 
     /**
      * Setup authentication

--- a/Library/Phalcon/Http/Client/Provider/Curl.php
+++ b/Library/Phalcon/Http/Client/Provider/Curl.php
@@ -201,7 +201,7 @@ class Curl extends Request
         foreach ($params as $value) {
             if (
                 (is_string($value) && strpos($value, '@') === 0)
-                or ($classCurlFile && $value instanceof $classCurlFile)
+                || ($classCurlFile && $value instanceof $classCurlFile)
             ) {
                 return false;
             }

--- a/Library/Phalcon/Http/Client/Provider/Curl.php
+++ b/Library/Phalcon/Http/Client/Provider/Curl.php
@@ -176,7 +176,7 @@ class Curl extends Request
     protected function initPostFields($params, $useEncoding = true)
     {
         if (is_array($params)) {
-            if ($useEncoding and $this->canUseEncoding($params)) {
+            if ($useEncoding && $this->canUseEncoding($params)) {
                 $params = http_build_query($params);
             }
         }
@@ -185,7 +185,7 @@ class Curl extends Request
             $this->setOption(CURLOPT_POSTFIELDS, $params);
         }
     }
-  
+
     /**
      * Returns if can url-encode params.
      *
@@ -200,14 +200,14 @@ class Curl extends Request
             : null;
         foreach ($params as $value) {
             if (
-                (is_string($value) and strpos($value, '@') === 0)
-                or ($classCurlFile and is_a($value, $classCurlFile))
+                (is_string($value) && strpos($value, '@') === 0)
+                or ($classCurlFile && $value instanceof $classCurlFile)
             ) {
                 return false;
             }
         }
         return true;
-    }  
+    } 
 
     /**
      * Setup authentication

--- a/Library/Phalcon/Http/Client/Provider/Curl.php
+++ b/Library/Phalcon/Http/Client/Provider/Curl.php
@@ -193,7 +193,7 @@ class Curl extends Request
      *
      * @return bool
      */
-    private function canUseEncoding(array $params)
+    protected function canUseEncoding(array $params)
     {
         $classCurlFile = class_exists('\CURLFile')
             ? '\CURLFile'


### PR DESCRIPTION
Should check each param if is a `\CURLFile` f.e. created via `curl_file_create($file)`.

Example:

    $provider = \Phalcon\Http\Client\Request::getProvider();

    // POST a file
    $file = '/home/mine/myimage.jpg';
    $response = $provider->post('me/upload', [
        'access_token' => 1234,
        'file'         => curl_file_create(realpath($file)),
    ]);

    echo $response->header->statusCode;

Reason:
See `CURLOPT_SAFE_UPLOAD` http://php.net/manual/en/function.curl-setopt.php

`Added in PHP 5.5.0 with FALSE as the default value. PHP 5.6.0 changes the default value to TRUE.`
_and disabled with PHP 7_ 