### PR TITLE
Fixed lost curl error

### DIFF
--- a/Library/Phalcon/Db/Adapter/MongoDB/Operation/FindOneAndReplace.php
+++ b/Library/Phalcon/Db/Adapter/MongoDB/Operation/FindOneAndReplace.php
@@ -122,7 +122,7 @@ class FindOneAndReplace implements Executable
 
         $options['new']=$options['returnDocument']===self::RETURN_DOCUMENT_AFTER;
 
-        unset($options['projection'],$options['returnDocument']);
+        unset($options['projection'], $options['returnDocument']);
 
         $this->findAndModify=new FindAndModify($databaseName, $collectionName, ['query' =>$filter,
                                                                               'update'=>$replacement

--- a/Library/Phalcon/Db/Adapter/MongoDB/Operation/FindOneAndUpdate.php
+++ b/Library/Phalcon/Db/Adapter/MongoDB/Operation/FindOneAndUpdate.php
@@ -122,7 +122,7 @@ class FindOneAndUpdate implements Executable
 
         $options['new']=$options['returnDocument']===self::RETURN_DOCUMENT_AFTER;
 
-        unset($options['projection'],$options['returnDocument']);
+        unset($options['projection'], $options['returnDocument']);
 
         $this->findAndModify=new FindAndModify($databaseName, $collectionName, ['query' =>$filter,
                                                                               'update'=>$update

--- a/Library/Phalcon/Http/Client/Provider/Curl.php
+++ b/Library/Phalcon/Http/Client/Provider/Curl.php
@@ -149,8 +149,6 @@ class Curl extends Request
 
         $content = curl_exec($this->handle);
 
-        $this->setOption(CURLOPT_HEADERFUNCTION, null);
-
         if ($errno = curl_errno($this->handle)) {
             throw new HttpException(curl_error($this->handle), $errno);
         }
@@ -159,6 +157,8 @@ class Curl extends Request
         $response->header->parse($this->responseHeader);
 
         $response->body = $content;
+
+        $this->setOption(CURLOPT_HEADERFUNCTION, null);
 
         return $response;
     }


### PR DESCRIPTION
Moving __destruct -fix ("release" Curl instance from header function) to bottom -- before return.
 