### PR TITLE
Use new PHPUnit class autoloader,PHPUnit version to ^5 - old stable, #727

### DIFF
--- a/Library/Phalcon/Test/FunctionalTestCase.php
+++ b/Library/Phalcon/Test/FunctionalTestCase.php
@@ -93,13 +93,13 @@ abstract class FunctionalTestCase extends ModelTestCase
      * Assert that the last dispatched controller matches the given controller class name
      *
      * @param  string $expected The expected controller name
-     * @throws \PHPUnit_Framework_ExpectationFailedException
+     * @throws \PHPUnit\Framework\ExpectationFailedException
      */
     public function assertController($expected)
     {
         $actual = $this->di->getShared('dispatcher')->getControllerName();
         if ($actual != $expected) {
-            throw new \PHPUnit_Framework_ExpectationFailedException(
+            throw new \PHPUnit\Framework\ExpectationFailedException(
                 sprintf(
                     'Failed asserting Controller name "%s", actual Controller name is "%s"',
                     $expected,
@@ -115,13 +115,13 @@ abstract class FunctionalTestCase extends ModelTestCase
      * Assert that the last dispatched action matches the given action name
      *
      * @param  string $expected The expected action name
-     * @throws \PHPUnit_Framework_ExpectationFailedException
+     * @throws \PHPUnit\Framework\ExpectationFailedException
      */
     public function assertAction($expected)
     {
         $actual = $this->di->getShared('dispatcher')->getActionName();
         if ($actual != $expected) {
-            throw new \PHPUnit_Framework_ExpectationFailedException(
+            throw new \PHPUnit\Framework\ExpectationFailedException(
                 sprintf(
                     'Failed asserting Action name "%s", actual Action name is "%s"',
                     $expected,
@@ -139,14 +139,14 @@ abstract class FunctionalTestCase extends ModelTestCase
      * </code>
      *
      * @param  array $expected The expected headers
-     * @throws \PHPUnit_Framework_ExpectationFailedException
+     * @throws \PHPUnit\Framework\ExpectationFailedException
      */
     public function assertHeader(array $expected)
     {
         foreach ($expected as $expectedField => $expectedValue) {
             $actualValue = $this->di->getShared('response')->getHeaders()->get($expectedField);
             if ($actualValue != $expectedValue) {
-                throw new \PHPUnit_Framework_ExpectationFailedException(
+                throw new \PHPUnit\Framework\ExpectationFailedException(
                     sprintf(
                         'Failed asserting "%s" has a value of "%s", actual "%s" header value is "%s"',
                         $expectedField,
@@ -164,7 +164,7 @@ abstract class FunctionalTestCase extends ModelTestCase
      * Asserts that the response code matches the given one
      *
      * @param  string $expected the expected response code
-     * @throws \PHPUnit_Framework_ExpectationFailedException
+     * @throws \PHPUnit\Framework\ExpectationFailedException
      */
     public function assertResponseCode($expected)
     {
@@ -176,7 +176,7 @@ abstract class FunctionalTestCase extends ModelTestCase
         $actualValue = $this->di->getShared('response')->getHeaders()->get('Status');
 
         if (empty($actualValue) || stristr($actualValue, $expected) === false) {
-            throw new \PHPUnit_Framework_ExpectationFailedException(
+            throw new \PHPUnit\Framework\ExpectationFailedException(
                 sprintf(
                     'Failed asserting response code is "%s", actual response status is "%s"',
                     $expected,
@@ -191,7 +191,7 @@ abstract class FunctionalTestCase extends ModelTestCase
     /**
      * Asserts that the dispatch is forwarded
      *
-     * @throws \PHPUnit_Framework_ExpectationFailedException
+     * @throws \PHPUnit\Framework\ExpectationFailedException
      */
     public function assertDispatchIsForwarded()
     {
@@ -200,7 +200,7 @@ abstract class FunctionalTestCase extends ModelTestCase
         $actual = $dispatcher->wasForwarded();
 
         if (!$actual) {
-            throw new \PHPUnit_Framework_ExpectationFailedException('Failed asserting dispatch was forwarded');
+            throw new \PHPUnit\Framework\ExpectationFailedException('Failed asserting dispatch was forwarded');
         }
 
         $this->assertTrue($actual);
@@ -210,18 +210,18 @@ abstract class FunctionalTestCase extends ModelTestCase
      * Assert location redirect
      *
      * @param  string $location
-     * @throws \PHPUnit_Framework_ExpectationFailedException
+     * @throws \PHPUnit\Framework\ExpectationFailedException
      */
     public function assertRedirectTo($location)
     {
         $actualLocation = $this->di->getShared('response')->getHeaders()->get('Location');
 
         if (!$actualLocation) {
-            throw new \PHPUnit_Framework_ExpectationFailedException('Failed asserting response caused a redirect');
+            throw new \PHPUnit\Framework\ExpectationFailedException('Failed asserting response caused a redirect');
         }
 
         if ($actualLocation !== $location) {
-            throw new \PHPUnit_Framework_ExpectationFailedException(sprintf(
+            throw new \PHPUnit\Framework\ExpectationFailedException(sprintf(
                 'Failed asserting response redirects to "%s". It redirects to "%s".',
                 $location,
                 $actualLocation

--- a/Library/Phalcon/Test/UnitTestCase.php
+++ b/Library/Phalcon/Test/UnitTestCase.php
@@ -20,7 +20,7 @@
 namespace Phalcon\Test;
 
 use Phalcon\Di\InjectionAwareInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Phalcon\Config;
 use Phalcon\Di\FactoryDefault;
 use Phalcon\Di;

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "phpdocumentor/reflection-docblock": "2.0.4",
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^5",
         "squizlabs/php_codesniffer": "^2.7",
         "codeception/codeception": "^2.2",
         "codeception/mockery-module": "^0.2",


### PR DESCRIPTION
Hello,

As talked in #727 ticket I created a pull request.

PHPUnit version was increased to ^5 which is old stable version and it still has fallback to PHPUnit_Framework_Testcase which ^6 does not have anymore.

At later time PHPUnit version must be increased to ^6 however codeception dependency does not support it yet.

Thanks
