### PR TITLE
fix for Warning: setlocale(): Specified locale name is too long

### DIFF
--- a/Library/Phalcon/Utils/Slug.php
+++ b/Library/Phalcon/Utils/Slug.php
@@ -73,7 +73,8 @@ class Slug
         $clean = trim($clean, $delimiter);
 
         // Revert back to the old locale
-        setlocale(LC_ALL, $oldLocale);
+        parse_str(str_replace(';', '&', $oldLocale), $loc);
+        setlocale(LC_ALL, $loc);
 
         return $clean;
     }


### PR DESCRIPTION
fix for Warning: setlocale(): Specified locale name is too long in PHP 7 and above

Hello!

* Type: bug fix
* Link to issue: Warning: setlocale(): Specified locale name is too long

This pull request affects the following components: **(please check boxes)**

* [x] Library
* [ ] Code Style
* [ ] Documentation
* [ ] Testing

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/incubator/blob/master/CONTRIBUTING.md)?
- [X] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

There's already a different pull request for a fix, not sure which is better, it needs to be tested deeper

Thanks
