### PR TITLE
Add MongoCollection Uniqueness compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ env:
     - ZEND_DONT_UNLOAD_MODULES=1
     - CC="ccache gcc"
     - PATH="$PATH:~/bin"
-    - PHALCON_VERSION="v3.0.4"
+    - PHALCON_VERSION="3.1.x"
 
 before_install:
   - phpenv config-rm xdebug.ini || true

--- a/Library/Phalcon/Validation/Validator/CardNumber.php
+++ b/Library/Phalcon/Validation/Validator/CardNumber.php
@@ -22,7 +22,7 @@ namespace Phalcon\Validation\Validator;
 use Phalcon\Validation;
 use Phalcon\Validation\Message;
 use Phalcon\Validation\Validator;
-use Phalcon\Validation\Exception;
+use Phalcon\Validation\Exception as ValidationException;
 
 /**
  * Phalcon\Mvc\Model\Validator\CardNumber
@@ -75,7 +75,7 @@ class CardNumber extends Validator
                     $result = ($issuer == 4);
                     break;
                 default:
-                    throw new Exception('Incorrect type specifier');
+                    throw new ValidationException('Incorrect type specifier');
             }
 
             if (false === $result) {

--- a/Library/Phalcon/Validation/Validator/ConfirmationOf.php
+++ b/Library/Phalcon/Validation/Validator/ConfirmationOf.php
@@ -21,7 +21,7 @@ namespace Phalcon\Validation\Validator;
 
 use Phalcon\Validation;
 use Phalcon\Validation\Validator;
-use Phalcon\Validation\Exception;
+use Phalcon\Validation\Exception as ValidationException;
 
 /**
  * Validates confirmation of other field value
@@ -50,7 +50,7 @@ class ConfirmationOf extends Validator
     public function validate(Validation $validation, $attribute)
     {
         if (!$this->hasOption('origField')) {
-            throw new Exception('Original field must be set');
+            throw new ValidationException('Original field must be set');
         }
 
         $allowEmpty = $this->getOption('allowEmpty');

--- a/Library/Phalcon/Validation/Validator/Decimal.php
+++ b/Library/Phalcon/Validation/Validator/Decimal.php
@@ -5,7 +5,7 @@ namespace Phalcon\Validation\Validator;
 use Phalcon\Validation;
 use Phalcon\Validation\Message;
 use Phalcon\Validation\Validator;
-use Phalcon\Validation\Exception;
+use Phalcon\Validation\Exception as ValidationException;
 
 /**
  * Phalcon\Validation\Validator\Decimal
@@ -47,7 +47,7 @@ class Decimal extends Validator
         }
 
         if (false === $this->hasOption('places')) {
-            throw new Exception('A number of decimal places must be set');
+            throw new ValidationException('A number of decimal places must be set');
         }
 
         if ($this->hasOption('digits')) {

--- a/Library/Phalcon/Validation/Validator/MongoId.php
+++ b/Library/Phalcon/Validation/Validator/MongoId.php
@@ -23,7 +23,7 @@ use MongoId as Id;
 use Phalcon\Validation;
 use Phalcon\Validation\Validator;
 use Phalcon\Validation\Message;
-use Phalcon\Validation\Exception;
+use Phalcon\Validation\Exception as ValidationException;
 
 /**
  * MongoId validator
@@ -41,7 +41,7 @@ class MongoId extends Validator
     public function validate(Validation $validation, $attribute)
     {
         if (!extension_loaded('mongo')) {
-            throw new Exception('Mongo extension is not available');
+            throw new ValidationException('Mongo extension is not available');
         }
 
         $value = $validation->getValue($attribute);

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": ">=5.5",
-        "ext-phalcon": "^3.0",
+        "ext-phalcon": "^3.1",
         "swiftmailer/swiftmailer": "~5.2"
     },
     "require-dev": {

--- a/tests/_data/collections/Robots.php
+++ b/tests/_data/collections/Robots.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Phalcon\Test\Collections;
+
+use Phalcon\Mvc\MongoCollection;
+
+/**
+ * Robots Collection
+ *
+ * @method static Robots[] find(array $parameters = null)
+ * @method static Robots findFirst(array $parameters = null)
+ *
+ * @property \MongoId _id
+ * @property string name
+ * @property string type
+ * @property int year
+ * @property string datetime
+ * @property string deleted
+ * @property string text
+ *
+ * @package Phalcon\Test\Collections
+ */
+class Robots extends MongoCollection
+{
+}

--- a/tests/_data/collections/Users.php
+++ b/tests/_data/collections/Users.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Phalcon\Test\Collections;
+
+use Phalcon\Mvc\MongoCollection;
+use Phalcon\Validation;
+use Phalcon\Validation\Validator\Email;
+use Phalcon\Validation\Validator\ExclusionIn;
+use Phalcon\Validation\Validator\InclusionIn;
+use Phalcon\Validation\Validator\PresenceOf;
+use Phalcon\Validation\Validator\Regex;
+use Phalcon\Validation\Validator\StringLength;
+use Phalcon\Validation\Validator\Uniqueness;
+
+class Users extends MongoCollection
+{
+    public function validation()
+    {
+        $validator = new Validation();
+        $validator
+            ->add('created_at', new PresenceOf())
+
+            ->add('email', new StringLength(['min' => '7', 'max' => '50']))
+            ->add('email', new Email())
+            ->add('email', new Uniqueness())
+
+            ->add('status', new ExclusionIn(['domain' => ['P', 'I', 'w']]))
+            ->add('status', new InclusionIn(['domain' => ['A', 'y', 'Z']]))
+            ->add('status', new Regex(['pattern' => '/[A-Z]/']));
+
+        return $this->validate($validator);
+    }
+}

--- a/tests/_support/Helper/CollectionTrait.php
+++ b/tests/_support/Helper/CollectionTrait.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Helper;
+
+use Codeception\Actor;
+use Phalcon\Mvc\Collection\Manager;
+use Phalcon\Db\Adapter\MongoDB\Client;
+use Phalcon\Di;
+
+/**
+ * Collection Initializer
+ *
+ * @package Helper
+ */
+trait CollectionTrait
+{
+    /**
+     * Executed before each test
+     */
+    protected function setupMongo(Actor $I)
+    {
+        if (!extension_loaded('mongodb')) {
+            $I->markTestSkipped('mongodb extension not loaded');
+        }
+
+        Di::reset();
+
+        $di = new Di();
+        $di->set('mongo', function() {
+            $dsn = 'mongodb://' . env('TEST_MONGODB_HOST', '127.0.0.1') . ':' . env('TEST_MONGODB_PORT', 27017);
+            $mongo = new Client($dsn);
+
+            return $mongo->selectDatabase(env('TEST_MONGODB_NAME', 'incubator'));
+        });
+
+        $di->set('collectionManager', Manager::class);
+    }
+}

--- a/tests/unit/Mvc/Collection/Helpers/UniquenessTrait.php
+++ b/tests/unit/Mvc/Collection/Helpers/UniquenessTrait.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace Phalcon\Test\Mvc\Collection\Helpers;
+
+use DateTime;
+use Phalcon\Validation;
+use Phalcon\Validation\Validator\Uniqueness;
+use UnitTester;
+
+trait UniquenessTrait
+{
+    private function testSingleField(UnitTester $I)
+    {
+        $validation = new Validation();
+        $validation->add('type', new Uniqueness());
+        $messages = $validation->validate(null, $this->robot);
+        $I->assertCount(0, $messages);
+        $I->assertTrue($this->robot->save());
+        $messages = $validation->validate(null, $this->robot);
+        $I->assertCount(0, $messages);
+        $messages = $validation->validate(null, $this->anotherRobot);
+        $I->assertCount(0, $messages);
+        $messages = $validation->validate(null, $this->deletedRobot);
+        $I->assertCount(1, $messages);
+    }
+
+    private function testSingleFieldConvert(UnitTester $I)
+    {
+        $validation = new Validation();
+        $validation->add(
+            'type',
+            new Uniqueness(
+                [
+                    'convert' => function (array $values) {
+                        $values['type'] = 'hydraulic'; // mechanical -> hydraulic
+                        return $values;
+                    },
+                ]
+            )
+        );
+        $messages = $validation->validate(null, $this->deletedRobot);
+        $I->assertCount(0, $messages);
+    }
+
+    private function testSingleFieldWithNull(UnitTester $I)
+    {
+        $validation = new Validation();
+        $validation->add('deleted', new Uniqueness());
+        $messages = $validation->validate(null, $this->robot);
+        $I->assertCount(0, $messages);
+        $messages = $validation->validate(null, $this->anotherRobot);
+        $I->assertCount(1, $messages);
+        $messages = $validation->validate(null, $this->deletedRobot);
+        $I->assertCount(0, $messages);
+    }
+
+    private function testMultipleFields(UnitTester $I)
+    {
+        $validation = new Validation();
+        $validation->add(['name', 'type'], new Uniqueness());
+        $messages = $validation->validate(null, $this->robot);
+        $I->assertCount(0, $messages);
+        $messages = $validation->validate(null, $this->anotherRobot);
+        $I->assertCount(0, $messages);
+        $messages = $validation->validate(null, $this->deletedRobot);
+        $I->assertCount(1, $messages);
+    }
+
+    private function testMultipleFieldsConvert(UnitTester $I)
+    {
+        $validation = new Validation();
+        $validation->add(
+            ['name', 'type'],
+            new Uniqueness(
+                [
+                    'convert' => function (array $values) {
+                        $values['type'] = 'hydraulic'; // mechanical -> hydraulic
+                        return $values;
+                    },
+                ]
+            )
+        );
+        $messages = $validation->validate(null, $this->deletedRobot);
+        $I->assertCount(0, $messages);
+    }
+
+    private function testMultipleFieldsWithNull(UnitTester $I)
+    {
+        $validation = new Validation();
+        $validation->add(['type', 'deleted'], new Uniqueness());
+        $messages = $validation->validate(null, $this->robot);
+        $I->assertCount(0, $messages);
+        $messages = $validation->validate(null, $this->anotherRobot);
+        $I->assertCount(0, $messages);
+        $messages = $validation->validate(null, $this->deletedRobot);
+        $I->assertCount(0, $messages);
+        $this->deletedRobot->deleted = null;
+        $messages = $validation->validate(null, $this->deletedRobot);
+        $I->assertCount(1, $messages);
+        $this->deletedRobot->deleted = (new DateTime())->format('Y-m-d H:i:s');
+    }
+
+    private function testExceptSingleFieldSingleExcept(UnitTester $I)
+    {
+        $validation = new Validation();
+        $validation->add(
+            'year',
+            new Uniqueness(
+                [
+                    'except' => 1972,
+                ]
+            )
+        );
+        $messages = $validation->validate(null, $this->robot);
+        $I->assertCount(0, $messages);
+        $I->assertTrue($this->anotherRobot->save());
+        $messages = $validation->validate(null, $this->deletedRobot);
+        $I->assertCount(1, $messages);
+    }
+
+    private function testExceptSingleFieldMultipleExcept(UnitTester $I)
+    {
+        $validation = new Validation();
+        $validation->add(
+            'year',
+            new Uniqueness(
+                [
+                    'except' => [1972, 1952],
+                ]
+            )
+        );
+        $messages = $validation->validate(null, $this->robot);
+        $I->assertCount(0, $messages);
+        $messages = $validation->validate(null, $this->anotherRobot);
+        $I->assertCount(0, $messages);
+    }
+
+    private function testExceptMultipleFieldSingleExcept(UnitTester $I)
+    {
+        $validation = new Validation();
+        $validation->add(
+            ['type', 'year'],
+            new Uniqueness(
+                [
+                    'except' => [
+                        'type' => 'hydraulic',
+                        'year' => 1952,
+                    ],
+                ]
+            )
+        );
+        $messages = $validation->validate(null, $this->deletedRobot);
+        $I->assertCount(0, $messages);
+        $this->deletedRobot->type = 'mechanical';
+        $this->deletedRobot->year = 1972;
+        $messages = $validation->validate(null, $this->deletedRobot);
+        $I->assertCount(1, $messages);
+        $this->deletedRobot->type = 'hydraulic';
+        $this->deletedRobot->year = 1952;
+    }
+
+    private function testExceptMultipleFieldMultipleExcept(UnitTester $I)
+    {
+        $validation = new Validation();
+        $validation->add(
+            ['year', 'type'],
+            new Uniqueness(
+                [
+                    'except' => [
+                        'year' => [1942, 1972],
+                        'type' => ['hydraulic', 'cyborg'],
+                    ],
+                ]
+            )
+        );
+        $messages = $validation->validate(null, $this->robot);
+        $I->assertCount(0, $messages);
+        $messages = $validation->validate(null, $this->anotherRobot);
+        $I->assertCount(0, $messages);
+    }
+
+    private function testConvertArrayReturnsArray(UnitTester $I)
+    {
+        $validation = new Validation();
+        $validation->add(
+            'type',
+            new Uniqueness(
+                [
+                    'convert' => function (array $values) {
+                        ($values);
+
+                        return null;
+                    },
+                ]
+            )
+        );
+        try {
+            $validation->validate(null, $this->robot);
+            $I->assertTrue(false);
+        } catch (\Exception $e) {
+            $I->assertTrue(true);
+        }
+    }
+}

--- a/tests/unit/Mvc/Collection/Helpers/ValidationBase.php
+++ b/tests/unit/Mvc/Collection/Helpers/ValidationBase.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace Phalcon\Test\Mvc\Collection\Helpers;
+
+use DateTime;
+use Phalcon\Test\Collections\Users;
+use Phalcon\Mvc\Model\Message;
+use UnitTester;
+
+class ValidationBase
+{
+    protected function success(UnitTester $I)
+    {
+        $collection = new Users();
+        $collection->email = 'fuego@hotmail.com';
+        $collection->created_at = (new DateTime())->format('Y-m-d H:i:s');
+        $collection->status = 'A';
+        $I->assertTrue($collection->save());
+    }
+
+    protected function presenceOf(UnitTester $I)
+    {
+        $collection = new Users();
+        $collection->email = 'diego@hotmail.com';
+        $collection->created_at = null;
+        $collection->status = 'A';
+        $I->assertFalse($collection->save());
+
+        $expected = [
+            Message::__set_state(
+                [
+                    '_message' => 'Field created_at is required',
+                    '_field'   => 'created_at',
+                    '_type'    => 'PresenceOf',
+                    '_code'    => 0,
+                ]
+            ),
+        ];
+
+        $I->assertEquals($expected, $collection->getMessages());
+    }
+
+    protected function email(UnitTester $I)
+    {
+        $collection = new Users();
+        $collection->email = 'fuego?=';
+        $collection->created_at = (new DateTime())->format('Y-m-d H:i:s');
+        $collection->status = 'A';
+        $I->assertFalse($collection->save());
+
+        $expected = [
+            Message::__set_state(
+                [
+                    '_message' => 'Field email must be an email address',
+                    '_field'   => 'email',
+                    '_type'    => 'Email',
+                    '_code'    => 0,
+                ]
+            ),
+        ];
+
+        $I->assertEquals($expected, $collection->getMessages());
+    }
+
+    protected function exclusionIn(UnitTester $I)
+    {
+        $collection = new Users();
+        $collection->email = 'serghei@hotmail.com';
+        $collection->created_at = (new DateTime())->format('Y-m-d H:i:s');
+        $collection->status = 'P';
+        $I->assertFalse($collection->save());
+
+        $expected = [
+            Message::__set_state(
+                [
+                    '_message' => 'Field status must not be a part of list: P, I, w',
+                    '_field'   => 'status',
+                    '_type'    => 'ExclusionIn',
+                    '_code'    => 0,
+                ]
+            ),
+            Message::__set_state(
+                [
+                    '_message' => 'Field status must be a part of list: A, y, Z',
+                    '_field'   => 'status',
+                    '_type'    => 'InclusionIn',
+                    '_code'    => 0,
+                ]
+            ),
+        ];
+
+        $I->assertEquals($expected, $collection->getMessages());
+    }
+
+    protected function inclusionIn(UnitTester $I)
+    {
+        $collection = new Users();
+        $collection->email = 'serghei@hotmail.com';
+        $collection->created_at = (new DateTime())->format('Y-m-d H:i:s');
+        $collection->status = 'R';
+        $I->assertFalse($collection->save());
+
+        $expected = [
+            Message::__set_state(
+                [
+                    '_message' => 'Field status must be a part of list: A, y, Z',
+                    '_field'   => 'status',
+                    '_type'    => 'InclusionIn',
+                    '_code'    => 0,
+                ]
+            ),
+        ];
+
+        $I->assertEquals($expected, $collection->getMessages());
+    }
+
+    protected function uniqueness1(UnitTester $I)
+    {
+        $collection = new Users();
+        $collection->email = 'jurigag@hotmail.com';
+        $collection->created_at = (new DateTime())->format('Y-m-d H:i:s');
+        $collection->status = 'A';
+        $I->assertTrue($collection->save());
+
+        $collection = new Users();
+        $collection->email = 'jurigag@hotmail.com';
+        $collection->created_at = (new DateTime())->format('Y-m-d H:i:s');
+        $collection->status = 'A';
+        $I->assertFalse($collection->save());
+
+        $expected = [
+            Message::__set_state(
+                [
+                    '_message' => 'Field email must be unique',
+                    '_field'   => 'email',
+                    '_type'    => 'Uniqueness',
+                    '_code'    => 0,
+                ]
+            ),
+        ];
+
+        $I->assertEquals($expected, $collection->getMessages());
+    }
+
+    protected function regex(UnitTester $I)
+    {
+        $collection = new Users();
+        $collection->email = 'andres@hotmail.com';
+        $collection->created_at = (new DateTime())->format('Y-m-d H:i:s');
+        $collection->status = 'y';
+        $I->assertFalse($collection->save());
+
+        $expected = [
+            Message::__set_state(
+                [
+                    '_message' => 'Field status does not match the required format',
+                    '_field'   => 'status',
+                    '_type'    => 'Regex',
+                    '_code'    => 0,
+                ]
+            ),
+        ];
+
+        $I->assertEquals($expected, $collection->getMessages());
+    }
+
+    protected function tooLong(UnitTester $I)
+    {
+        $collection = new Users();
+        $collection->email = str_repeat('a', 50).'@hotmail.com';
+        $collection->created_at = (new DateTime())->format('Y-m-d H:i:s');
+        $collection->status = 'A';
+        $I->assertFalse($collection->save());
+
+        $expected = [
+            Message::__set_state(
+                [
+                    '_message' => 'Field email must not exceed 50 characters long',
+                    '_field'   => 'email',
+                    '_type'    => 'TooLong',
+                    '_code'    => 0,
+                ]
+            ),
+        ];
+
+        $I->assertEquals($expected, $collection->getMessages());
+    }
+
+    protected function tooShort(UnitTester $I)
+    {
+        $collection = new Users();
+        $collection->email = 'a@b.c';
+        $collection->created_at = (new DateTime())->format('Y-m-d H:i:s');
+        $collection->status = 'A';
+        $I->assertFalse($collection->save());
+
+        $expected = [
+            Message::__set_state(
+                [
+                    '_message' => 'Field email must be at least 7 characters long',
+                    '_field'   => 'email',
+                    '_type'    => 'TooShort',
+                    '_code'    => 0,
+                ]
+            ),
+        ];
+
+        $I->assertEquals($expected, $collection->getMessages());
+    }
+}

--- a/tests/unit/Mvc/Collection/ValidationCest.php
+++ b/tests/unit/Mvc/Collection/ValidationCest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Phalcon\Test\Mvc\Collection;
+
+use DateTime;
+use Helper\CollectionTrait;
+use Phalcon\Test\Collections\Robots;
+use Phalcon\Test\Mvc\Collection\Helpers\UniquenessTrait;
+use Phalcon\Test\Mvc\Collection\Helpers\ValidationBase;
+use UnitTester;
+
+/**
+ * \Phalcon\Test\Mvc\Collection\ValidationCest
+ * Tests for Phalcon\Mvc\MongoCollection component
+ *
+ * @copyright (c) 2011-2017 Phalcon Team
+ * @link      https://www.phalconphp.com
+ * @author    Wojciech Ślawski <jurigag@gmail.com>
+ * @package   Phalcon\Test\Mvc\Collection
+ * @group     Db
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class ValidationCest extends ValidationBase
+{
+    /**
+     * @var Robots
+     */
+    private $robot;
+
+    /**
+     * @var Robots
+     */
+    private $anotherRobot;
+
+    /**
+     * @var Robots
+     */
+    private $deletedRobot;
+
+    use CollectionTrait;
+    use UniquenessTrait;
+
+    public function mongo(UnitTester $I)
+    {
+        $I->wantToTest("Collection validation");
+
+        $this->setupMongo($I);
+
+        $this->success($I);
+        $this->presenceOf($I);
+        $this->email($I);
+        $this->exclusionIn($I);
+        $this->inclusionIn($I);
+        $this->uniqueness1($I);
+        $this->regex($I);
+        $this->tooLong($I);
+        $this->tooShort($I);
+    }
+
+    public function mongoUniqueness(UnitTester $I)
+    {
+        $I->wantToTest("Collection Uniqueness validation");
+
+        $this->setupMongo($I);
+
+        $this->robot = new Robots();
+        $this->robot->name = 'Robotina';
+        $this->robot->type = 'mechanical';
+        $this->robot->year = 1972;
+        $this->robot->datetime = (new DateTime())->format('Y-m-d H:i:s');
+        $this->robot->deleted = null;
+        $this->robot->text = 'text';
+
+        $this->anotherRobot = new Robots();
+        $this->anotherRobot->name = 'Robotina';
+        $this->anotherRobot->type = 'hydraulic';
+        $this->anotherRobot->year = 1952;
+        $this->anotherRobot->datetime = (new DateTime())->format('Y-m-d H:i:s');
+        $this->anotherRobot->deleted = null;
+        $this->anotherRobot->text = 'text';
+
+        $this->deletedRobot = new Robots();
+        $this->deletedRobot->name = 'Robotina';
+        $this->deletedRobot->type = 'mechanical';
+        $this->deletedRobot->year = 1952;
+        $this->deletedRobot->datetime = (new DateTime())->format('Y-m-d H:i:s');
+        $this->deletedRobot->deleted = (new DateTime())->format('Y-m-d H:i:s');
+        $this->deletedRobot->text = 'text';
+
+        $this->testSingleField($I);
+        $this->testSingleFieldConvert($I);
+        $this->testSingleFieldWithNull($I);
+        $this->testMultipleFields($I);
+        $this->testMultipleFieldsConvert($I);
+        $this->testMultipleFieldsWithNull($I);
+        $this->testExceptSingleFieldSingleExcept($I);
+        $this->testExceptSingleFieldMultipleExcept($I);
+        $this->testExceptMultipleFieldSingleExcept($I);
+        $this->testExceptMultipleFieldMultipleExcept($I);
+        $this->testConvertArrayReturnsArray($I);
+    }
+}


### PR DESCRIPTION
_Hello!_

* Type: bug fix
* Link to issue: https://github.com/phalcon/incubator/issues/700

This pull request affects the following components: **(please check boxes)**

* [x] Library
* Code Style
* Documentation
* [x] Testing

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/incubator/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: this is adding compability for MongoCollection to work with `Phalcon\Validation\Validator\Uniqueness` since from phalcon 3.1.x Collection can use `Phalcon\Validation` component.

Thanks
