### PR TITLE
Normalize email object the same way as the array

### DIFF
--- a/Library/Phalcon/Mailer/Message.php
+++ b/Library/Phalcon/Mailer/Message.php
@@ -772,7 +772,7 @@ class Message
      */
     protected function normalizeEmail($email)
     {
-        if (is_array($email)) {
+        if (is_array($email) || is_object($email)) {
             $emails = [];
 
             foreach ($email as $k => $v) {


### PR DESCRIPTION
Fix
Warning: preg_match() expects parameter 2 to be string, object given

Hello!

* Type: bug fix
* Link to issue:

This pull request affects the following components: **(please check boxes)**

* [x] Library
* [ ] Code Style
* [ ] Documentation
* [ ] Testing

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/incubator/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Thanks
