### PR TITLE
Update _related property so Phalcon avoids to make a lazy loading

### DIFF
--- a/Library/Phalcon/Mvc/Model/EagerLoading/EagerLoad.php
+++ b/Library/Phalcon/Mvc/Model/EagerLoading/EagerLoad.php
@@ -163,6 +163,7 @@ final class EagerLoad
                     if (static::$isPhalcon2) {
                         $record->{$alias} = null;
                         $record->{$alias} = $referencedModels;
+                        $record->_related[$alias] = $referenceModels;
                     }
                 } else {
                     $record->{$alias} = null;


### PR DESCRIPTION
I need to know in phlacon model if the relationship is loaded. Actually it's impossible witthout something like this https://github.com/phalcon/cphalcon/pull/12772 because calling the property launchs the lazy loading.

Then, I need the eagerload library to fill that protected property in the model (impossible by any means, so we need to push changes to phalcon: a new method or more arguments in getRelated or something so we can fill the _related array with the eager loaded results from the Loader class);

References: https://github.com/stibiumz/phalcon.eager-loading/issues/12

Hello!

* Type: bug fix
* Link to issue: https://github.com/stibiumz/phalcon.eager-loading/issues/12

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/incubator/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Thanks
