### PR TITLE
Fixing Curl head request stuck

### DIFF
--- a/Library/Phalcon/Http/Client/Provider/Curl.php
+++ b/Library/Phalcon/Http/Client/Provider/Curl.php
@@ -334,6 +334,7 @@ class Curl extends Request
             CURLOPT_URL           => $uri->build(),
             CURLOPT_HTTPGET       => true,
             CURLOPT_CUSTOMREQUEST => Method::HEAD,
+            CURLOPT_NOBODY        => true,
         ]);
 
         return $this->send($customHeader, $fullResponse);


### PR DESCRIPTION
Added curl option `CURLOPT_NOBODY => true` to on ::head method