### PR TITLE
Phalcon\Db\Adapter\MongoDB\Operation:createCommand does not support collation option

### DIFF
--- a/Library/Phalcon/Db/Adapter/MongoDB/Operation/Aggregate.php
+++ b/Library/Phalcon/Db/Adapter/MongoDB/Operation/Aggregate.php
@@ -267,6 +267,10 @@ class Aggregate implements Executable
         if ($this->options['useCursor']) {
             $cmd['cursor']=isset($this->options["batchSize"])?['batchSize'=>$this->options["batchSize"]]:new stdClass;
         }
+        
+        if (isset($this->options['collation'])) {
+            $cmd['collation']=$this->options['collation'];
+        }
 
         return new Command($cmd);
     }


### PR DESCRIPTION
### Expected and Actual Behavior

MongoDB itself provides an option for the collection collation. (https://docs.mongodb.com/manual/reference/command/aggregate/)

`Phalcon\Db\Adapter\MongoDB\Operation:createCommand` does not support this option yet.

### Details

* Phalcon Framework version: 3.1.2
* Phalcon Incubator version: 3.1.1
* PHP Version: 7.1.3
* Operating System: Ubuntu 14.04
* Server:  Apache 2.4
* Other related info (Database, table schema): MongoDB 3.4.4
