### PR TITLE
Phalcon\Db\Adapter\MongoDB\Operation:createCommand does not support collation option

### DIFF
--- a/Library/Phalcon/Db/Adapter/MongoDB/Operation/Aggregate.php
+++ b/Library/Phalcon/Db/Adapter/MongoDB/Operation/Aggregate.php
@@ -245,10 +245,11 @@ class Aggregate implements Executable
 
         $cmd['allowDiskUse'] = $this->options['allowDiskUse'];
 
-        if (isset($this->options['bypassDocumentValidation']) && Functions::serverSupportsFeature(
-            $server,
-            self::$wireVersionForDocumentLevelValidation
-        )
+        if (isset($this->options['bypassDocumentValidation']) &&
+            Functions::serverSupportsFeature(
+                $server,
+                self::$wireVersionForDocumentLevelValidation
+            )
         ) {
             $cmd['bypassDocumentValidation'] = $this->options['bypassDocumentValidation'];
         }
@@ -258,16 +259,22 @@ class Aggregate implements Executable
         }
 
         if (isset($this->options['readConcern']) &&
-	    Functions::serverSupportsFeature($server, self::$wireVersionForReadConcern)
-	) {
+            Functions::serverSupportsFeature($server, self::$wireVersionForReadConcern)
+        ) {
             $cmd['readConcern'] = Functions::readConcernAsDocument($this->options['readConcern']);
         }
 
         if ($this->options['useCursor']) {
-            $cmd['cursor'] = isset($this->options["batchSize"]) ? ['batchSize'=>$this->options["batchSize"]] : new stdClass();
+            if (isset($this->options["batchSize"])) {
+            $cmd['cursor'] = ['batchSize' => $this->options["batchSize"]];
+        } else {
+            $cmd['cursor'] = new stdClass();
+          }
         }
 
-        if (isset($this->options['collation']) && Functions::serverSupportsFeature($server, self::$wireVersionForCollation)) {
+        if (isset($this->options['collation']) &&
+            Functions::serverSupportsFeature($server, self::$wireVersionForCollation)
+        ) {
             $cmd['collation'] = $this->options['collation'];
         }
 

--- a/Library/Phalcon/Db/Adapter/MongoDB/Operation/Aggregate.php
+++ b/Library/Phalcon/Db/Adapter/MongoDB/Operation/Aggregate.php
@@ -40,6 +40,7 @@ class Aggregate implements Executable
     private static $wireVersionForCursor=2;
     private static $wireVersionForDocumentLevelValidation=4;
     private static $wireVersionForReadConcern=4;
+    private static $wireVersionForCollation=5;
 
     private $databaseName;
     private $collectionName;
@@ -266,6 +267,10 @@ class Aggregate implements Executable
 
         if ($this->options['useCursor']) {
             $cmd['cursor']=isset($this->options["batchSize"])?['batchSize'=>$this->options["batchSize"]]:new stdClass;
+        }
+
+		if (isset($this->options['collation']) && Functions::serverSupportsFeature($server, self::$wireVersionForCollation)) {
+            $cmd['collation']=$this->options['collation'];
         }
 
         return new Command($cmd);

--- a/Library/Phalcon/Db/Adapter/MongoDB/Operation/Aggregate.php
+++ b/Library/Phalcon/Db/Adapter/MongoDB/Operation/Aggregate.php
@@ -266,10 +266,10 @@ class Aggregate implements Executable
 
         if ($this->options['useCursor']) {
             if (isset($this->options["batchSize"])) {
-            $cmd['cursor'] = ['batchSize' => $this->options["batchSize"]];
-        } else {
-            $cmd['cursor'] = new stdClass();
-          }
+                $cmd['cursor'] = ['batchSize' => $this->options["batchSize"]];
+            } else {
+                $cmd['cursor'] = new stdClass();
+            }
         }
 
         if (isset($this->options['collation']) &&

--- a/Library/Phalcon/Db/Adapter/MongoDB/Operation/Aggregate.php
+++ b/Library/Phalcon/Db/Adapter/MongoDB/Operation/Aggregate.php
@@ -243,34 +243,32 @@ class Aggregate implements Executable
             return new Command($cmd);
         }
 
-        $cmd['allowDiskUse']=$this->options['allowDiskUse'];
+        $cmd['allowDiskUse'] = $this->options['allowDiskUse'];
 
-        if (isset($this->options['bypassDocumentValidation'])&&Functions::serverSupportsFeature(
+        if (isset($this->options['bypassDocumentValidation']) && Functions::serverSupportsFeature(
             $server,
             self::$wireVersionForDocumentLevelValidation
         )
         ) {
-            $cmd['bypassDocumentValidation']=$this->options['bypassDocumentValidation'];
+            $cmd['bypassDocumentValidation'] = $this->options['bypassDocumentValidation'];
         }
 
         if (isset($this->options['maxTimeMS'])) {
-            $cmd['maxTimeMS']=$this->options['maxTimeMS'];
+            $cmd['maxTimeMS'] = $this->options['maxTimeMS'];
         }
 
-        if (isset($this->options['readConcern'])&&Functions::serverSupportsFeature(
-            $server,
-            self::$wireVersionForReadConcern
-        )
-        ) {
-            $cmd['readConcern']=Functions::readConcernAsDocument($this->options['readConcern']);
+        if (isset($this->options['readConcern']) &&
+	    Functions::serverSupportsFeature($server, self::$wireVersionForReadConcern)
+	) {
+            $cmd['readConcern'] = Functions::readConcernAsDocument($this->options['readConcern']);
         }
 
         if ($this->options['useCursor']) {
-            $cmd['cursor']=isset($this->options["batchSize"])?['batchSize'=>$this->options["batchSize"]]:new stdClass;
+            $cmd['cursor'] = isset($this->options["batchSize"]) ? ['batchSize'=>$this->options["batchSize"]] : new stdClass();
         }
 
-		if (isset($this->options['collation']) && Functions::serverSupportsFeature($server, self::$wireVersionForCollation)) {
-            $cmd['collation']=$this->options['collation'];
+        if (isset($this->options['collation']) && Functions::serverSupportsFeature($server, self::$wireVersionForCollation)) {
+            $cmd['collation'] = $this->options['collation'];
         }
 
         return new Command($cmd);


### PR DESCRIPTION
### Expected and Actual Behavior

MongoDB itself provides an option for the collection collation. (https://docs.mongodb.com/manual/reference/command/aggregate/)

`Phalcon\Db\Adapter\MongoDB\Operation:createCommand` does not support this option yet.

### Details

* Phalcon Framework version: 3.1.2
* Phalcon Incubator version: 3.1.1
* PHP Version: 7.1.3
* Operating System: Ubuntu 14.04
* Server:  Apache 2.4
* Other related info (Database, table schema): MongoDB 3.4.4
