### PR TITLE
fix Issue 759. delete notice about supporting php <5.4 in README.md

### DIFF
--- a/Library/Phalcon/Mvc/Model/README.md
+++ b/Library/Phalcon/Mvc/Model/README.md
@@ -51,6 +51,4 @@ $robots = Robot::with(
 
 ```
 
-PHP versions under 5.4 do not support traits, use instead `Phalcon\Mvc\Model\EagerLoading\Loader` methods
-
 Distributed as single package at https://github.com/stibiumz/phalcon.eager-loading


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #759

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/incubator/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change: deleted notice about supporting php <5.4 in README.md

Thanks
