### PR TITLE
Loss the context

### DIFF
--- a/Library/Phalcon/Logger/Adapter/Database.php
+++ b/Library/Phalcon/Logger/Adapter/Database.php
@@ -103,7 +103,7 @@ class Database extends LoggerAdapter implements AdapterInterface
     public function getFormatter()
     {
         if (!is_object($this->_formatter)) {
-            $this->_formatter = new LineFormatter();
+            $this->_formatter = new LineFormatter('%message%');
         }
 
         return $this->_formatter;
@@ -122,7 +122,7 @@ class Database extends LoggerAdapter implements AdapterInterface
     {
         return $this->db->execute(
             'INSERT INTO ' . $this->options['table'] . ' VALUES (null, ?, ?, ?, ?)',
-            [$this->name, $type, $message, $time],
+            [$this->name, $type, $this->getFormatter()->format($message, $type, $time, $context), $time],
             [Column::BIND_PARAM_STR, Column::BIND_PARAM_INT, Column::BIND_PARAM_STR, Column::BIND_PARAM_INT]
         );
     }


### PR DESCRIPTION
* Type: bug fix

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/incubator/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change: 

When the message have any variable from context `{user} lost in {place} ` the information in context is losed. Modify formatter default template to store only the message. Type and time are stored in different columns. Then in the message column, I add the result of the formatter to store the right value