### PR TITLE
Fix deleteNode BUG

### DIFF
--- a/Library/Phalcon/Mvc/Model/Behavior/NestedSet.php
+++ b/Library/Phalcon/Mvc/Model/Behavior/NestedSet.php
@@ -578,7 +578,6 @@ class NestedSet extends Behavior implements BehaviorInterface
                     return false;
                 }
             }
-            $this->ignoreEvent = false;
         }
 
         $key = $owner->{$this->rightAttribute} + 1;


### PR DESCRIPTION
* Type: bug fix

Hello! 
When I use deleteNode, I encountered this error  
You should not use Sl\Models\Areas:beforeUpdate when Phalcon\Mvc\Model\Behavior\NestedSet attached. Use the methods of behavior.
I found that there is a problem in line 581, I am not sure if it is BUG, but I removed it, it worked.

Thanks
