### PR TITLE
Fix deleteNode BUG

### DIFF
--- a/Library/Phalcon/Mvc/Model/Behavior/NestedSet.php
+++ b/Library/Phalcon/Mvc/Model/Behavior/NestedSet.php
@@ -578,7 +578,7 @@ class NestedSet extends Behavior implements BehaviorInterface
                     return false;
                 }
             }
-            $this->ignoreEvent = false;
+           
         }
 
         $key = $owner->{$this->rightAttribute} + 1;


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/incubator/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

When I use deleteNode, I encountered this error  
You should not use `Sl\Models\Areas:beforeUpdate` when `Phalcon\Mvc\Model\Behavior\NestedSet` attached. Use the methods of behavior.
I found that there is a problem in line 581, I am not sure if it is BUG, but I removed it, it worked.


Thanks