### PR TITLE
NestedSet deleteNode method fix, issue 603

### DIFF
--- a/Library/Phalcon/Mvc/Model/Behavior/NestedSet.php
+++ b/Library/Phalcon/Mvc/Model/Behavior/NestedSet.php
@@ -560,7 +560,6 @@ class NestedSet extends Behavior implements BehaviorInterface
 
                 return false;
             }
-            $this->ignoreEvent = false;
         } else {
             $condition = $this->leftAttribute . '>=' . $owner->{$this->leftAttribute} . ' AND ';
             $condition .= $this->rightAttribute . '<=' . $owner->{$this->rightAttribute};
@@ -578,12 +577,12 @@ class NestedSet extends Behavior implements BehaviorInterface
                     return false;
                 }
             }
-            $this->ignoreEvent = false;
         }
 
         $key = $owner->{$this->rightAttribute} + 1;
         $delta = $owner->{$this->leftAttribute} - $owner->{$this->rightAttribute} - 1;
         $this->shiftLeftRight($key, $delta);
+        $this->ignoreEvent = false;
 
         $this->db->commit();
 

--- a/tests/unit/Mvc/Model/Behavior/NestedSetTest.php
+++ b/tests/unit/Mvc/Model/Behavior/NestedSetTest.php
@@ -419,4 +419,21 @@ class NestedSetTest extends Helper
             }
         );
     }
+
+    /**
+     * Delete node
+     *
+     * @author Serhii Svyrydenko <sergey.v.sviridenko@gmail.com>
+     * @since  2017-06-08
+     * @issue  603
+     */
+    public function testShouldDeleteNode()
+    {
+
+        $this->createTree();
+        $samsung = CategoriesManyRoots::findFirst(2);
+        $actual = $samsung->deleteNode();
+
+        $this->assertTrue($actual);
+    }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #603

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/incubator/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change: fix deleteNode() method. ignoreEvent flag with false status  became after shiftLeftRight() method

Thanks
