### PR TITLE
Change query in read method of Session adapter

### DIFF
--- a/Library/Phalcon/Session/Adapter/Database.php
+++ b/Library/Phalcon/Session/Adapter/Database.php
@@ -26,6 +26,7 @@ use Phalcon\Session\Adapter;
 use Phalcon\Session\AdapterInterface;
 use Phalcon\Session\Exception;
 use Phalcon\Db\AdapterInterface as DbAdapter;
+use Phalcon\Db\Column;
 
 /**
  * Phalcon\Session\Adapter\Database
@@ -121,7 +122,8 @@ class Database extends Adapter implements AdapterInterface
                 $maxLifetime
             ),
             Db::FETCH_NUM,
-            [$sessionId, time()]
+            [$sessionId, time()],
+            [Column::BIND_PARAM_STR, Column::BIND_PARAM_INT]
         );
 
         if (empty($row)) {
@@ -151,7 +153,7 @@ class Database extends Adapter implements AdapterInterface
             [$sessionId]
         );
 
-        if (!empty($row) && intval($row[0]) > 0) {
+        if ($row[0] > 0) {
             return $this->connection->execute(
                 sprintf(
                     'UPDATE %s SET %s = ?, %s = ? WHERE %s = ?',

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "codeception/specify": "^0.4",
         "codeception/verify": "^0.3",
         "vlucas/phpdotenv": "^2.4",
-        "phalcon/dd": "^1.1"
+        "phalcon/dd": "^1.1",
+        "doctrine/instantiator": "1.0.5"
     },
     "suggest": {
         "ext-aerospike": "*",
@@ -64,7 +65,8 @@
             "Phalcon\\Test\\Behavior\\Blameable\\": "tests/_data/behavior/blameable",
             "Phalcon\\Test\\Aerospike\\": "tests/aerospike/",
             "Phalcon\\Test\\Unit5x\\": "tests/unit5x/",
-            "Phalcon\\Test\\Collections\\": "tests/_data/collections"
+            "Phalcon\\Test\\Collections\\": "tests/_data/collections",
+            "Phalcon\\Test\\Module\\": "tests/_support/Module"
         },
         "files": [
             "tests/_support/functions.php"

--- a/tests/_data/dump.sql
+++ b/tests/_data/dump.sql
@@ -1252,6 +1252,7 @@ CREATE TABLE `cache_data` (
   `lifetime` INT,
   PRIMARY KEY(`key_name`)
 );
+
 DROP TABLE IF EXISTS `robots`;
 CREATE TABLE `robots` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -1259,6 +1260,7 @@ CREATE TABLE `robots` (
   `type` varchar(32) COLLATE utf8_unicode_ci NOT NULL default 'mechanical',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
 DROP TABLE if EXISTS `audit`;
 CREATE TABLE `audit` (
   `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -1270,6 +1272,7 @@ CREATE TABLE `audit` (
   `primary_key` TEXT DEFAULT NULL, /* for BC reasons */
   PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
 DROP TABLE if EXISTS `audit_detail`;
 CREATE TABLE `audit_detail` (
   `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -1279,3 +1282,11 @@ CREATE TABLE `audit_detail` (
   `new_value` TEXT NOT NULL,
   PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+DROP TABLE if EXISTS `session`;
+CREATE TABLE `sessions` (
+  session_id TEXT NOT NULL,
+  data TEXT,
+  created_at INT,
+  modified_at INT
+)ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/tests/_support/Helper/Session/Dialect/DatabaseTrait.php
+++ b/tests/_support/Helper/Session/Dialect/DatabaseTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Helper\Session\Dialect;
+
+/**
+ * Helper\Session\Dialect\DatabaseTrait
+ *
+ * @copyright (c) 2011-2017 Phalcon Team
+ * @link      https://phalconphp.com
+ * @author    Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>
+ * @package   Helper\Session\Dialect
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+trait DatabaseTrait
+{
+    protected function getWrittenSessionData($sessionID)
+    {
+        $sql = "DELETE FROM sessions WHERE session_id = '{$sessionID}'";
+
+        return $sql;
+    }
+}

--- a/tests/_support/Helper/Session/Dialect/ModelSession.php
+++ b/tests/_support/Helper/Session/Dialect/ModelSession.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Helper\Session\Dialect;
+
+/**
+ * Helper\Session\Dialect\ModelSession
+ *
+ * @copyright (c) 2011-2017 Phalcon Team
+ * @link      https://phalconphp.com
+ * @author    Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>
+ * @package   Helper\Session\Dialect
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+
+use Phalcon\Mvc\Model;
+use Phalcon\Mvc\ModelInterface;
+
+class ModelSession extends Model
+{
+    public static $table = 'sessions';
+}

--- a/tests/_support/Module/UnitTest.php
+++ b/tests/_support/Module/UnitTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Phalcon\Test\Module;
+
+use UnitTester;
+use Codeception\Specify;
+use Codeception\Test\Unit;
+use PHPUnit_Runner_Version;
+
+/**
+ * \Phalcon\Test\Module\UnitTest
+ * Base class for all Unit tests
+ *
+ * @copyright (c) 2011-2017 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Nikolaos Dimopoulos <nikos@phalconphp.com>
+ * @package   Phalcon\Test\Module
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class UnitTest extends Unit
+{
+    use Specify;
+
+    /**
+     * UnitTester Object
+     * @var UnitTester
+     */
+    protected $tester;
+}

--- a/tests/unit/Session/Adapter/DatabaseTest.php
+++ b/tests/unit/Session/Adapter/DatabaseTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Phalcon\Test\Session\Adapter;
+
+use Phalcon\Db\Adapter\Pdo\Mysql;
+use Phalcon\Session\Adapter\Database;
+use Phalcon\Db;
+use Phalcon\Db\Column;
+use Phalcon\Session\AdapterInterface;
+use Helper\Session\Dialect\DatabaseTrait;
+use Phalcon\Test\Module\UnitTest;
+use Helper\Session\Dialect\ModelSession;
+
+/**
+ * \Phalcon\Test\Session\Adapter
+ * Tests for Phalcon\Session\Adapter components
+ *
+ * @copyright (c) 2011-2017 Phalcon Team
+ * @link      https://www.phalconphp.com
+ * @author    Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>
+ * @package   Phalcon\Test\Session\Adapter
+ * @group     Db
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class DatabaseTest extends UnitTest
+{
+    use DatabaseTrait;
+
+    /**
+     * @var DbAdapter
+     */
+    protected $connection;
+
+    /**
+     * @var SessionAdapter
+     */
+    protected $session;
+
+    /**
+     * executed before each test
+     */
+    protected function _before()
+    {
+        $this->connection = new Mysql(
+            [
+                'host'     => env('TEST_DB_HOST', '127.0.0.1'),
+                'username' => env('TEST_DB_USER', 'incubator'),
+                'password' => env('TEST_DB_PASSWD', 'secret'),
+                'dbname'   => env('TEST_DB_NAME', 'incubator'),
+                'charset'  => env('TEST_DB_CHARSET', 'utf8'),
+                'port'     => env('TEST_DB_PORT', 3306)
+            ]
+        );
+
+        $this->session = new Database([
+            'db' => $this->connection,
+            'table' => 'sessions',
+            'lifetime' => 3600
+        ]);
+    }
+
+    /**
+     * Tests Database::write
+     *
+     * @test
+     * @author Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>
+     * @since  2017-07-24
+     */
+    public function shouldWorkSessionAdapter()
+    {
+        $this->session->start();
+        $sessionID = $this->session->getId();
+        $this->session->set('customer_id', 'somekey');
+        $this->specify(
+            "Method set() hasn't worked",
+            function ($data, $expected) {
+                expect($data)->equals($expected);
+            },
+            [
+                'examples' => [
+                    [$_SESSION['customer_id'], 'somekey']
+                ]
+            ]
+        );
+
+
+        $this->session->write($sessionID, session_encode());
+        $this->tester->seeInDatabase(ModelSession::$table, ['session_id' => $sessionID]);
+        $this->tester->seeInDatabase(ModelSession::$table, ['data' => 'customer_id|s:7:"somekey";']);
+        $this->session->remove('customer_id');
+
+
+        $sessionData = $this->session->read($sessionID);
+        session_start();
+        session_decode($sessionData);
+
+        $this->specify(
+            "Method read() hasn't worked",
+            function ($data, $expected) {
+                expect($data)->equals($expected);
+            },
+            [
+                'examples' => [
+                    [$_SESSION['customer_id'], 'somekey']
+                ]
+            ]
+        );
+
+        $this->session->set('customer_id', 'somekey');
+        $this->session->set('customer_id2', 'somekey2');
+        $this->session->write($sessionID, session_encode());
+        $this->tester->seeInDatabase(ModelSession::$table, ['session_id' => $sessionID]);
+        $this->tester->seeInDatabase(ModelSession::$table, ['data' => 'customer_id|s:7:"somekey";customer_id2|s:8:"somekey2";']);
+        $this->session->remove('customer_id');
+        $this->session->remove('customer_id2');
+
+        $sessionData = $this->session->read($sessionID);
+        session_start();
+        session_decode($sessionData);
+
+        $this->specify(
+            "Method update() hasn't worked",
+            function ($data, $expected) {
+                expect($data)->equals($expected);
+            },
+            [
+                'examples' => [
+                    [$_SESSION['customer_id'], 'somekey'],
+                    [$_SESSION['customer_id2'], 'somekey2']
+                ]
+            ]
+        );
+
+        $this->connection->execute($this->getWrittenSessionData($sessionID));
+        $this->tester->dontSeeInDatabase(ModelSession::$table, ['session_id' => $sessionID]);
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #682

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/incubator/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:
Fixed method `read` that returned empty array

Thanks
