### PR TITLE
fix view when engines are objects

### DIFF
--- a/Library/Phalcon/Mailer/Manager.php
+++ b/Library/Phalcon/Mailer/Manager.php
@@ -338,7 +338,15 @@ class Manager extends Component
             $view = $this->getDI()->get('\Phalcon\Mvc\View\Simple');
             $view->setViewsDir($viewsDir);
 
-            if ($engines = $viewApp->getRegisteredEngines()) {
+            if ($registeredEngines = $viewApp->getRegisteredEngines()) {
+                $engines = [];
+                foreach ($registeredEngines as $key => $engine) {
+                    if (is_object($engine)) {
+                        $engines[$key] = get_class($engine);
+                    } else {
+                        $engines[$key] = $engine;
+                    }
+                }
                 $view->registerEngines($engines);
             }
 


### PR DESCRIPTION
Hello!

* Type: bug fix

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/incubator/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:
Phalcon\Mvc\View\Simple doesn't render views if `registeredEngines` contains on array of objects as engines (it only works with strings). This PR is fixing the problem by getting the class of the object.

Thanks
