### PR TITLE
Phalcon\Acl\Adapter\Redis - Add deep inherits when array passed to addInherit

### DIFF
--- a/Library/Phalcon/Acl/Adapter/Redis.php
+++ b/Library/Phalcon/Acl/Adapter/Redis.php
@@ -120,13 +120,23 @@ class Redis extends Adapter
         }
 
         /**
-         * Deep inherits
+         * Deep inherits Explicit tests array, Implicit recurs through inheritance chain
          */
         if( is_array( $roleToInherit ) ) {
+
             foreach ($roleToInherit as $roleToInherit) {
                 $this->redis->sAdd("rolesInherits:$roleName", $roleToInherit);
             }
             return true;
+        }
+
+        if($this->redis->exists("rolesInherits:$roleToInherit")) {
+
+            $deeperInherits = $this->redis->sGetMembers("rolesInherits:$roleToInherit");
+
+            foreach($deeperInherits as $deeperInherit) {
+                $this->addInherit($roleName,$deeperInherit);
+            }
         }
 
         $this->redis->sAdd("rolesInherits:$roleName", $roleToInherit);

--- a/Library/Phalcon/Acl/Adapter/Redis.php
+++ b/Library/Phalcon/Acl/Adapter/Redis.php
@@ -119,6 +119,16 @@ class Redis extends Adapter
             $roleToInherit = $roleToInherit->getName();
         }
 
+        /**
+         * Deep inherits
+         */
+        if( is_array( $roleToInherit ) ) {
+            foreach ($roleToInherit as $roleToInherit) {
+                $this->redis->sAdd("rolesInherits:$roleName", $roleToInherit);
+            }
+            return true;
+        }
+
         $this->redis->sAdd("rolesInherits:$roleName", $roleToInherit);
     }
 


### PR DESCRIPTION
Hello!

* Type: new feature 

Small description of change:

I have provisioned in the adapter for the following use of the adapter:
```
            //Add Inherits
            $inherits = [
                'user' => ['guest'],
                'poweruser' => ['user','guest'],
                'admin' => ['poweruser', 'user', 'guest'],
                'sysadmin' => ['admin','poweruser','user','guest']
            ];

            foreach ($inherits as $inherit => $base) {
                $acl->addInherit($inherit, $base);
            }
```

Inherits will not allow deep inherits as in \Phalcon\Acl\Adapter\Memory. 

This is a quick win as it is already provision for in Phalcon\Acl\Adapter\Redis::isAllowed.

Thanks
