### PR TITLE
Add Explicit and Implicit Deep Inherits to Phalcon\Acl\Adapter\Redis::addInherit

### DIFF
--- a/Library/Phalcon/Acl/Adapter/Redis.php
+++ b/Library/Phalcon/Acl/Adapter/Redis.php
@@ -101,6 +101,12 @@ class Redis extends Adapter
     /**
      * {@inheritdoc}
      *
+     * Example:
+     * //Administrator implicitly inherits all descendants of 'consultor' unless explicity set in an Array
+     * <code>$acl->addInherit('administrator', new Phalcon\Acl\Role('consultor'));</code>
+     * <code>$acl->addInherit('administrator', 'consultor');</code>
+     * <code>$acl->addInherit('administrator', ['consultor', 'poweruser']);</code>
+     *
      * @param  string $roleName
      * @param  \Phalcon\Acl\Role|string $roleToInherit
      * @throws \Phalcon\Acl\Exception

--- a/Library/Phalcon/Acl/Adapter/Redis.php
+++ b/Library/Phalcon/Acl/Adapter/Redis.php
@@ -120,13 +120,23 @@ class Redis extends Adapter
         }
 
         /**
-         * Deep inherits
+         * Deep inherits Explicit tests array, Implicit recurs through inheritance chain
          */
         if( is_array( $roleToInherit ) ) {
+
             foreach ($roleToInherit as $roleToInherit) {
                 $this->redis->sAdd("rolesInherits:$roleName", $roleToInherit);
             }
             return true;
+        }
+
+        if($this->redis->exists("rolesInherits:$roleToInherit")) {
+
+            $deeperInherits = $this->redis->sGetMembers("rolesInherits:$roleToInherit");
+
+            foreach($deeperInherits as $deeperInherit) {
+                $this->addInherit($roleName,$deeperInherit);
+            }
         }
 
         $this->redis->sAdd("rolesInherits:$roleName", $roleToInherit);

--- a/Library/Phalcon/Acl/Adapter/Redis.php
+++ b/Library/Phalcon/Acl/Adapter/Redis.php
@@ -119,6 +119,16 @@ class Redis extends Adapter
             $roleToInherit = $roleToInherit->getName();
         }
 
+        /**
+         * Deep inherits
+         */
+        if( is_array( $roleToInherit ) ) {
+            foreach ($roleToInherit as $roleToInherit) {
+                $this->redis->sAdd("rolesInherits:$roleName", $roleToInherit);
+            }
+            return true;
+        }
+
         $this->redis->sAdd("rolesInherits:$roleName", $roleToInherit);
     }
 

--- a/Library/Phalcon/Acl/Adapter/Redis.php
+++ b/Library/Phalcon/Acl/Adapter/Redis.php
@@ -122,20 +122,18 @@ class Redis extends Adapter
         /**
          * Deep inherits Explicit tests array, Implicit recurs through inheritance chain
          */
-        if( is_array( $roleToInherit ) ) {
-
+        if (is_array($roleToInherit)) {
             foreach ($roleToInherit as $roleToInherit) {
                 $this->redis->sAdd("rolesInherits:$roleName", $roleToInherit);
             }
             return true;
         }
 
-        if($this->redis->exists("rolesInherits:$roleToInherit")) {
-
+        if ($this->redis->exists("rolesInherits:$roleToInherit")) {
             $deeperInherits = $this->redis->sGetMembers("rolesInherits:$roleToInherit");
 
-            foreach($deeperInherits as $deeperInherit) {
-                $this->addInherit($roleName,$deeperInherit);
+            foreach ($deeperInherits as $deeperInherit) {
+                $this->addInherit($roleName, $deeperInherit);
             }
         }
 


### PR DESCRIPTION
Hello!

Type: new feature
Small description of change:

I have provisioned in the adapter for the following use of the adapter:

            //Add Inherits Explicit
            $inherits = [
                'user' => ['guest'],
                'poweruser' => ['user','guest'],
                'admin' => ['poweruser', 'user', 'guest'],
                'sysadmin' => ['admin','poweruser','user','guest']
            ];

            foreach ($inherits as $inherit => $base) {
                $acl->addInherit($inherit, $base);
            }

            //Add Inherits Implicit
            $inherits = [
                'user' => 'guest',
                'poweruser' => 'user',
                'admin' => 'poweruser',
                'sysadmin' => 'admin'
            ];

            foreach ($inherits as $inherit => $base) {
                $acl->addInherit($inherit, $base);
            }


Inherits will now allow deep inherits as in \Phalcon\Acl\Adapter\Memory.

This is a quick win as it is already provision for in Phalcon\Acl\Adapter\Redis::isAllowed.

Thanks