### PR TITLE
Update MongoCollection.php to return array

### DIFF
--- a/Library/Phalcon/Mvc/MongoCollection.php
+++ b/Library/Phalcon/Mvc/MongoCollection.php
@@ -307,7 +307,7 @@ abstract class MongoCollection extends PhalconCollection implements Unserializab
         $cursor = $mongoCollection->find($conditions, $options);
 
 
-        $cursor->setTypeMap(['root' => get_class($base), 'document' => 'array']);
+        $cursor->setTypeMap(['root' => get_class($base), 'document' => 'array', "root" => "array", "array" => "array"]);
 
         if (true === $unique) {
             /**


### PR DESCRIPTION
Hello!

* Type: new feature

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/incubator/blob/master/CONTRIBUTING.md)?
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

This will return models as arrays instead of just returning the document.

Thanks
