### PR TITLE
Add arrayFilter option

### DIFF
--- a/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
+++ b/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
@@ -138,7 +138,7 @@ class Update implements Executable
 	    
         if(isset($this->options['arrayFilters'])) {
             $updateOptions['arrayFilters'] = $this->options['arrayFilters'];
-	}
+        }
 
         $bulkOptions=[];
 

--- a/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
+++ b/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
@@ -153,7 +153,7 @@ class Update implements Executable
         if (isset($this->options['bypassDocumentValidation']) && Functions::serverSupportsFeature(
             $server,
             self::$wireVersionForDocumentLevelValidation
-            )
+        )
         ) {
             $bulkOptions['bypassDocumentValidation'] = $this->options['bypassDocumentValidation'];
         }

--- a/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
+++ b/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
@@ -36,7 +36,7 @@ use Phalcon\Db\Adapter\MongoDB\Exception\InvalidArgumentException;
  */
 class Update implements Executable
 {
-    private static $wireVersionForDocumentLevelValidation=4;
+    private static $wireVersionForDocumentLevelValidation = 4;
 
     private $databaseName;
     private $collectionName;

--- a/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
+++ b/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
@@ -34,137 +34,140 @@ use Phalcon\Db\Adapter\MongoDB\Exception\InvalidArgumentException;
  *
  * @package Phalcon\Db\Adapter\MongoDB\Operation
  */
-class Update implements Executable {
-	private static $wireVersionForDocumentLevelValidation = 4;
+class Update implements Executable
+{
+    private static $wireVersionForDocumentLevelValidation = 4;
 
-	private $databaseName;
-	private $collectionName;
-	private $filter;
-	private $update;
-	private $options;
+    private $databaseName;
+    private $collectionName;
+    private $filter;
+    private $update;
+    private $options;
 
-	/**
-	 * Constructs a update command.
-	 *
-	 * Supported options:
-	 *
-	 *  * bypassDocumentValidation (boolean): If true, allows the write to opt
-	 *    out of document level validation.
-	 *
-	 *  * multi (boolean): When true, updates all documents matching the query.
-	 *    This option cannot be true if the $update argument is a replacement
-	 *    document (i.e. contains no update operators). The default is false.
-	 *
-	 *  * upsert (boolean): When true, a new document is created if no document
-	 *    matches the query. The default is false.
-	 *
-	 *  * writeConcern (MongoDB\Driver\WriteConcern): Write concern.
-	 *
-	 * @param string $databaseName Database name
-	 * @param string $collectionName Collection name
-	 * @param array|object $filter Query by which to delete documents
-	 * @param array|object $update Update to apply to the matched
-	 *                                     document(s) or a replacement document
-	 * @param array $options Command options
-	 *
-	 * @throws InvalidArgumentException
-	 */
-	public function __construct( $databaseName, $collectionName, $filter, $update, array $options = [] ) {
-		if ( ! is_array( $filter ) && ! is_object( $filter ) ) {
-			throw InvalidArgumentException::invalidType( '$filter', $filter, 'array or object' );
-		}
+    /**
+     * Constructs a update command.
+     *
+     * Supported options:
+     *
+     *  * bypassDocumentValidation (boolean): If true, allows the write to opt
+     *    out of document level validation.
+     *
+     *  * multi (boolean): When true, updates all documents matching the query.
+     *    This option cannot be true if the $update argument is a replacement
+     *    document (i.e. contains no update operators). The default is false.
+     *
+     *  * upsert (boolean): When true, a new document is created if no document
+     *    matches the query. The default is false.
+     *
+     *  * writeConcern (MongoDB\Driver\WriteConcern): Write concern.
+     *
+     * @param string $databaseName Database name
+     * @param string $collectionName Collection name
+     * @param array|object $filter Query by which to delete documents
+     * @param array|object $update Update to apply to the matched
+     *                                     document(s) or a replacement document
+     * @param array $options Command options
+     *
+     * @throws InvalidArgumentException
+     */
+    public function __construct($databaseName, $collectionName, $filter, $update, array $options = [])
+    {
+        if ( ! is_array($filter) && ! is_object($filter)) {
+            throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');
+        }
 
-		if ( ! is_array( $update ) && ! is_object( $update ) ) {
-			throw InvalidArgumentException::invalidType( '$update', $filter, 'array or object' );
-		}
+        if ( ! is_array($update) && ! is_object($update)) {
+            throw InvalidArgumentException::invalidType('$update', $filter, 'array or object');
+        }
 
-		$options += [
-			'multi'  => false,
-			'upsert' => false,
-		];
+        $options += [
+            'multi'  => false,
+            'upsert' => false,
+        ];
 
-		if ( isset( $options['bypassDocumentValidation'] ) && ! is_bool( $options['bypassDocumentValidation'] ) ) {
-			throw InvalidArgumentException::invalidType(
-				'"bypassDocumentValidation" option',
-				$options['bypassDocumentValidation'],
-				'boolean'
-			);
-		}
+        if (isset($options['bypassDocumentValidation']) && ! is_bool($options['bypassDocumentValidation'])) {
+            throw InvalidArgumentException::invalidType(
+                '"bypassDocumentValidation" option',
+                $options['bypassDocumentValidation'],
+                'boolean'
+            );
+        }
 
-		if ( ! is_bool( $options['multi'] ) ) {
-			throw InvalidArgumentException::invalidType(
-				'"multi" option',
-				$options['multi'],
-				'boolean'
-			);
-		}
+        if ( ! is_bool($options['multi'])) {
+            throw InvalidArgumentException::invalidType(
+                '"multi" option',
+                $options['multi'],
+                'boolean'
+            );
+        }
 
-		if ( $options['multi'] && ! Functions::isFirstKeyOperator( $update ) ) {
-			throw new InvalidArgumentException( '"multi" option cannot be true if $update is a replacement document' );
-		}
+        if ($options['multi'] && ! Functions::isFirstKeyOperator($update)) {
+            throw new InvalidArgumentException('"multi" option cannot be true if $update is a replacement document');
+        }
 
-		if ( ! is_bool( $options['upsert'] ) ) {
-			throw InvalidArgumentException::invalidType(
-				'"upsert" option',
-				$options['upsert'],
-				'boolean'
-			);
-		}
+        if ( ! is_bool($options['upsert'])) {
+            throw InvalidArgumentException::invalidType(
+                '"upsert" option',
+                $options['upsert'],
+                'boolean'
+            );
+        }
 
-		if ( isset( $options['writeConcern'] ) && ! $options['writeConcern'] instanceof WriteConcern ) {
-			throw InvalidArgumentException::invalidType(
-				'"writeConcern" option',
-				$options['writeConcern'],
-				'MongoDB\Driver\WriteConcern'
-			);
-		}
+        if (isset($options['writeConcern']) && ! $options['writeConcern'] instanceof WriteConcern) {
+            throw InvalidArgumentException::invalidType(
+                '"writeConcern" option',
+                $options['writeConcern'],
+                'MongoDB\Driver\WriteConcern'
+            );
+        }
 
-		$this->databaseName   = (string) $databaseName;
-		$this->collectionName = (string) $collectionName;
-		$this->filter         = $filter;
-		$this->update         = $update;
-		$this->options        = $options;
-	}
+        $this->databaseName   = (string)$databaseName;
+        $this->collectionName = (string)$collectionName;
+        $this->filter         = $filter;
+        $this->update         = $update;
+        $this->options        = $options;
+    }
 
-	/**
-	 * Execute the operation.
-	 *
-	 * @see Executable::execute()
-	 *
-	 * @param Server $server
-	 *
-	 * @return UpdateResult
-	 */
-	public function execute( Server $server ) {
-		$updateOptions = [
-			'multi'  => $this->options['multi'],
-			'upsert' => $this->options['upsert']
-		];
+    /**
+     * Execute the operation.
+     *
+     * @see Executable::execute()
+     *
+     * @param Server $server
+     *
+     * @return UpdateResult
+     */
+    public function execute(Server $server)
+    {
+        $updateOptions = [
+            'multi'  => $this->options['multi'],
+            'upsert' => $this->options['upsert']
+        ];
 
-		if ( isset( $this->options['arrayFilters'] ) ) {
-			$updateOptions['arrayFilters'] = $this->options['arrayFilters'];
-		}
+        if (isset($this->options['arrayFilters'])) {
+            $updateOptions['arrayFilters'] = $this->options['arrayFilters'];
+        }
 
-		$bulkOptions = [];
+        $bulkOptions = [];
 
-		if ( isset( $this->options['bypassDocumentValidation'] ) && Functions::serverSupportsFeature(
-				$server,
-				self::$wireVersionForDocumentLevelValidation
-			)
-		) {
-			$bulkOptions['bypassDocumentValidation'] = $this->options['bypassDocumentValidation'];
-		}
+        if (isset($this->options['bypassDocumentValidation']) && Functions::serverSupportsFeature(
+                $server,
+                self::$wireVersionForDocumentLevelValidation
+            )
+        ) {
+            $bulkOptions['bypassDocumentValidation'] = $this->options['bypassDocumentValidation'];
+        }
 
-		$bulk = new Bulk( $bulkOptions );
-		$bulk->update( $this->filter, $this->update, $updateOptions );
+        $bulk = new Bulk($bulkOptions);
+        $bulk->update($this->filter, $this->update, $updateOptions);
 
-		$writeConcern = isset( $this->options['writeConcern'] ) ? $this->options['writeConcern'] : null;
-		$writeResult  = $server->executeBulkWrite(
-			$this->databaseName . '.' . $this->collectionName,
-			$bulk,
-			$writeConcern
-		);
+        $writeConcern = isset($this->options['writeConcern']) ? $this->options['writeConcern'] : null;
+        $writeResult  = $server->executeBulkWrite(
+            $this->databaseName . '.' . $this->collectionName,
+            $bulk,
+            $writeConcern
+        );
 
-		return new UpdateResult( $writeResult );
-	}
+        return new UpdateResult($writeResult);
+    }
 }

--- a/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
+++ b/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
@@ -72,11 +72,11 @@ class Update implements Executable
      */
     public function __construct($databaseName, $collectionName, $filter, $update, array $options = [])
     {
-        if (!is_array($filter)&&!is_object($filter)) {
+        if (!is_array($filter) && !is_object($filter)) {
             throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');
         }
 
-        if (!is_array($update)&&!is_object($update)) {
+        if (!is_array($update) && !is_object($update)) {
             throw InvalidArgumentException::invalidType('$update', $filter, 'array or object');
         }
 
@@ -85,7 +85,7 @@ class Update implements Executable
             'upsert'=>false,
         ];
 
-        if (isset($options['bypassDocumentValidation'])&&!is_bool($options['bypassDocumentValidation'])) {
+        if (isset($options['bypassDocumentValidation']) && !is_bool($options['bypassDocumentValidation'])) {
             throw InvalidArgumentException::invalidType(
                 '"bypassDocumentValidation" option',
                 $options['bypassDocumentValidation'],
@@ -94,18 +94,26 @@ class Update implements Executable
         }
 
         if (!is_bool($options['multi'])) {
-            throw InvalidArgumentException::invalidType('"multi" option', $options['multi'], 'boolean');
+            throw InvalidArgumentException::invalidType(
+            	'"multi" option',
+	            $options['multi'],
+	            'boolean'
+            );
         }
 
-        if ($options['multi']&&!Functions::isFirstKeyOperator($update)) {
+        if ($options['multi'] && !Functions::isFirstKeyOperator($update)) {
             throw new InvalidArgumentException('"multi" option cannot be true if $update is a replacement document');
         }
 
         if (!is_bool($options['upsert'])) {
-            throw InvalidArgumentException::invalidType('"upsert" option', $options['upsert'], 'boolean');
+            throw InvalidArgumentException::invalidType(
+            	'"upsert" option',
+	            $options['upsert'],
+	            'boolean'
+            );
         }
 
-        if (isset($options['writeConcern'])&&!$options['writeConcern'] instanceof WriteConcern) {
+        if (isset($options['writeConcern']) && !$options['writeConcern'] instanceof WriteConcern) {
             throw InvalidArgumentException::invalidType(
                 '"writeConcern" option',
                 $options['writeConcern'],
@@ -113,11 +121,11 @@ class Update implements Executable
             );
         }
 
-        $this->databaseName  =(string)$databaseName;
-        $this->collectionName=(string)$collectionName;
-        $this->filter        =$filter;
-        $this->update        =$update;
-        $this->options       =$options;
+        $this->databaseName = (string)$databaseName;
+        $this->collectionName = (string)$collectionName;
+        $this->filter = $filter;
+        $this->update = $update;
+        $this->options = $options;
     }
 
     /**
@@ -131,30 +139,34 @@ class Update implements Executable
      */
     public function execute(Server $server)
     {
-        $updateOptions=[
-            'multi' =>$this->options['multi'],
-            'upsert'=>$this->options['upsert'],
+        $updateOptions = [
+            'multi' => $this->options['multi'],
+            'upsert' => $this->options['upsert']
         ];
 
         if (isset($this->options['arrayFilters'])) {
             $updateOptions['arrayFilters'] = $this->options['arrayFilters'];
         }
 
-        $bulkOptions=[];
+        $bulkOptions = [];
 
         if (isset($this->options['bypassDocumentValidation']) && Functions::serverSupportsFeature(
             $server,
             self::$wireVersionForDocumentLevelValidation
         )
         ) {
-            $bulkOptions['bypassDocumentValidation']=$this->options['bypassDocumentValidation'];
+            $bulkOptions['bypassDocumentValidation'] = $this->options['bypassDocumentValidation'];
         }
 
-        $bulk=new Bulk($bulkOptions);
+        $bulk = new Bulk($bulkOptions);
         $bulk->update($this->filter, $this->update, $updateOptions);
 
-        $writeConcern=isset($this->options['writeConcern'])?$this->options['writeConcern']:null;
-        $writeResult =$server->executeBulkWrite($this->databaseName.'.'.$this->collectionName, $bulk, $writeConcern);
+        $writeConcern = isset($this->options['writeConcern']) ? $this->options['writeConcern'] : null;
+        $writeResult = $server->executeBulkWrite(
+            $this->databaseName.'.'.$this->collectionName,
+            $bulk,
+            $writeConcern
+        );
 
         return new UpdateResult($writeResult);
     }

--- a/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
+++ b/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
@@ -95,9 +95,9 @@ class Update implements Executable
 
         if (!is_bool($options['multi'])) {
             throw InvalidArgumentException::invalidType(
-            	'"multi" option',
-	            $options['multi'],
-	            'boolean'
+                '"multi" option',
+                $options['multi'],
+                'boolean'
             );
         }
 
@@ -107,9 +107,9 @@ class Update implements Executable
 
         if (!is_bool($options['upsert'])) {
             throw InvalidArgumentException::invalidType(
-            	'"upsert" option',
-	            $options['upsert'],
-	            'boolean'
+                '"upsert" option',
+                $options['upsert'],
+                'boolean'
             );
         }
 

--- a/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
+++ b/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
@@ -135,8 +135,8 @@ class Update implements Executable
             'multi' =>$this->options['multi'],
             'upsert'=>$this->options['upsert'],
         ];
-	    
-        if(isset($this->options['arrayFilters'])) {
+
+        if (isset($this->options['arrayFilters'])) {
             $updateOptions['arrayFilters'] = $this->options['arrayFilters'];
         }
 

--- a/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
+++ b/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
@@ -72,11 +72,11 @@ class Update implements Executable
      */
     public function __construct($databaseName, $collectionName, $filter, $update, array $options = [])
     {
-        if ( ! is_array($filter) && ! is_object($filter)) {
+        if (! is_array($filter) && ! is_object($filter)) {
             throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');
         }
 
-        if ( ! is_array($update) && ! is_object($update)) {
+        if (! is_array($update) && ! is_object($update)) {
             throw InvalidArgumentException::invalidType('$update', $filter, 'array or object');
         }
 
@@ -93,7 +93,7 @@ class Update implements Executable
             );
         }
 
-        if ( ! is_bool($options['multi'])) {
+        if (! is_bool($options['multi'])) {
             throw InvalidArgumentException::invalidType(
                 '"multi" option',
                 $options['multi'],
@@ -105,7 +105,7 @@ class Update implements Executable
             throw new InvalidArgumentException('"multi" option cannot be true if $update is a replacement document');
         }
 
-        if ( ! is_bool($options['upsert'])) {
+        if (! is_bool($options['upsert'])) {
             throw InvalidArgumentException::invalidType(
                 '"upsert" option',
                 $options['upsert'],
@@ -151,8 +151,8 @@ class Update implements Executable
         $bulkOptions = [];
 
         if (isset($this->options['bypassDocumentValidation']) && Functions::serverSupportsFeature(
-                $server,
-                self::$wireVersionForDocumentLevelValidation
+            $server,
+            self::$wireVersionForDocumentLevelValidation
             )
         ) {
             $bulkOptions['bypassDocumentValidation'] = $this->options['bypassDocumentValidation'];

--- a/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
+++ b/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
@@ -142,7 +142,7 @@ class Update implements Executable
 
         $bulkOptions=[];
 
-        if (isset($this->options['bypassDocumentValidation'])&&Functions::serverSupportsFeature(
+        if (isset($this->options['bypassDocumentValidation']) && Functions::serverSupportsFeature(
             $server,
             self::$wireVersionForDocumentLevelValidation
         )

--- a/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
+++ b/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
@@ -135,9 +135,10 @@ class Update implements Executable
             'multi' =>$this->options['multi'],
             'upsert'=>$this->options['upsert'],
         ];
-      
-        if(isset($this->options['arrayFilters']))
-		      $updateOptions['arrayFilters'] = $this->options['arrayFilters'];
+	    
+        if(isset($this->options['arrayFilters'])) {
+            $updateOptions['arrayFilters'] = $this->options['arrayFilters'];
+	}
 
         $bulkOptions=[];
 

--- a/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
+++ b/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
@@ -34,140 +34,137 @@ use Phalcon\Db\Adapter\MongoDB\Exception\InvalidArgumentException;
  *
  * @package Phalcon\Db\Adapter\MongoDB\Operation
  */
-class Update implements Executable
-{
-    private static $wireVersionForDocumentLevelValidation = 4;
+class Update implements Executable {
+	private static $wireVersionForDocumentLevelValidation = 4;
 
-    private $databaseName;
-    private $collectionName;
-    private $filter;
-    private $update;
-    private $options;
+	private $databaseName;
+	private $collectionName;
+	private $filter;
+	private $update;
+	private $options;
 
-    /**
-     * Constructs a update command.
-     *
-     * Supported options:
-     *
-     *  * bypassDocumentValidation (boolean): If true, allows the write to opt
-     *    out of document level validation.
-     *
-     *  * multi (boolean): When true, updates all documents matching the query.
-     *    This option cannot be true if the $update argument is a replacement
-     *    document (i.e. contains no update operators). The default is false.
-     *
-     *  * upsert (boolean): When true, a new document is created if no document
-     *    matches the query. The default is false.
-     *
-     *  * writeConcern (MongoDB\Driver\WriteConcern): Write concern.
-     *
-     * @param string       $databaseName Database name
-     * @param string       $collectionName Collection name
-     * @param array|object $filter Query by which to delete documents
-     * @param array|object $update Update to apply to the matched
-     *                                     document(s) or a replacement document
-     * @param array        $options Command options
-     *
-     * @throws InvalidArgumentException
-     */
-    public function __construct($databaseName, $collectionName, $filter, $update, array $options = [])
-    {
-        if (!is_array($filter) && !is_object($filter)) {
-            throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');
-        }
+	/**
+	 * Constructs a update command.
+	 *
+	 * Supported options:
+	 *
+	 *  * bypassDocumentValidation (boolean): If true, allows the write to opt
+	 *    out of document level validation.
+	 *
+	 *  * multi (boolean): When true, updates all documents matching the query.
+	 *    This option cannot be true if the $update argument is a replacement
+	 *    document (i.e. contains no update operators). The default is false.
+	 *
+	 *  * upsert (boolean): When true, a new document is created if no document
+	 *    matches the query. The default is false.
+	 *
+	 *  * writeConcern (MongoDB\Driver\WriteConcern): Write concern.
+	 *
+	 * @param string $databaseName Database name
+	 * @param string $collectionName Collection name
+	 * @param array|object $filter Query by which to delete documents
+	 * @param array|object $update Update to apply to the matched
+	 *                                     document(s) or a replacement document
+	 * @param array $options Command options
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	public function __construct( $databaseName, $collectionName, $filter, $update, array $options = [] ) {
+		if ( ! is_array( $filter ) && ! is_object( $filter ) ) {
+			throw InvalidArgumentException::invalidType( '$filter', $filter, 'array or object' );
+		}
 
-        if (!is_array($update) && !is_object($update)) {
-            throw InvalidArgumentException::invalidType('$update', $filter, 'array or object');
-        }
+		if ( ! is_array( $update ) && ! is_object( $update ) ) {
+			throw InvalidArgumentException::invalidType( '$update', $filter, 'array or object' );
+		}
 
-        $options+=[
-            'multi' =>false,
-            'upsert'=>false,
-        ];
+		$options += [
+			'multi'  => false,
+			'upsert' => false,
+		];
 
-        if (isset($options['bypassDocumentValidation']) && !is_bool($options['bypassDocumentValidation'])) {
-            throw InvalidArgumentException::invalidType(
-                '"bypassDocumentValidation" option',
-                $options['bypassDocumentValidation'],
-                'boolean'
-            );
-        }
+		if ( isset( $options['bypassDocumentValidation'] ) && ! is_bool( $options['bypassDocumentValidation'] ) ) {
+			throw InvalidArgumentException::invalidType(
+				'"bypassDocumentValidation" option',
+				$options['bypassDocumentValidation'],
+				'boolean'
+			);
+		}
 
-        if (!is_bool($options['multi'])) {
-            throw InvalidArgumentException::invalidType(
-                '"multi" option',
-                $options['multi'],
-                'boolean'
-            );
-        }
+		if ( ! is_bool( $options['multi'] ) ) {
+			throw InvalidArgumentException::invalidType(
+				'"multi" option',
+				$options['multi'],
+				'boolean'
+			);
+		}
 
-        if ($options['multi'] && !Functions::isFirstKeyOperator($update)) {
-            throw new InvalidArgumentException('"multi" option cannot be true if $update is a replacement document');
-        }
+		if ( $options['multi'] && ! Functions::isFirstKeyOperator( $update ) ) {
+			throw new InvalidArgumentException( '"multi" option cannot be true if $update is a replacement document' );
+		}
 
-        if (!is_bool($options['upsert'])) {
-            throw InvalidArgumentException::invalidType(
-                '"upsert" option',
-                $options['upsert'],
-                'boolean'
-            );
-        }
+		if ( ! is_bool( $options['upsert'] ) ) {
+			throw InvalidArgumentException::invalidType(
+				'"upsert" option',
+				$options['upsert'],
+				'boolean'
+			);
+		}
 
-        if (isset($options['writeConcern']) && !$options['writeConcern'] instanceof WriteConcern) {
-            throw InvalidArgumentException::invalidType(
-                '"writeConcern" option',
-                $options['writeConcern'],
-                'MongoDB\Driver\WriteConcern'
-            );
-        }
+		if ( isset( $options['writeConcern'] ) && ! $options['writeConcern'] instanceof WriteConcern ) {
+			throw InvalidArgumentException::invalidType(
+				'"writeConcern" option',
+				$options['writeConcern'],
+				'MongoDB\Driver\WriteConcern'
+			);
+		}
 
-        $this->databaseName = (string)$databaseName;
-        $this->collectionName = (string)$collectionName;
-        $this->filter = $filter;
-        $this->update = $update;
-        $this->options = $options;
-    }
+		$this->databaseName   = (string) $databaseName;
+		$this->collectionName = (string) $collectionName;
+		$this->filter         = $filter;
+		$this->update         = $update;
+		$this->options        = $options;
+	}
 
-    /**
-     * Execute the operation.
-     *
-     * @see Executable::execute()
-     *
-     * @param Server $server
-     *
-     * @return UpdateResult
-     */
-    public function execute(Server $server)
-    {
-        $updateOptions = [
-            'multi' => $this->options['multi'],
-            'upsert' => $this->options['upsert']
-        ];
+	/**
+	 * Execute the operation.
+	 *
+	 * @see Executable::execute()
+	 *
+	 * @param Server $server
+	 *
+	 * @return UpdateResult
+	 */
+	public function execute( Server $server ) {
+		$updateOptions = [
+			'multi'  => $this->options['multi'],
+			'upsert' => $this->options['upsert']
+		];
 
-        if (isset($this->options['arrayFilters'])) {
-            $updateOptions['arrayFilters'] = $this->options['arrayFilters'];
-        }
+		if ( isset( $this->options['arrayFilters'] ) ) {
+			$updateOptions['arrayFilters'] = $this->options['arrayFilters'];
+		}
 
-        $bulkOptions = [];
+		$bulkOptions = [];
 
-        if (isset($this->options['bypassDocumentValidation']) && Functions::serverSupportsFeature(
-            $server,
-            self::$wireVersionForDocumentLevelValidation
-        )
-        ) {
-            $bulkOptions['bypassDocumentValidation'] = $this->options['bypassDocumentValidation'];
-        }
+		if ( isset( $this->options['bypassDocumentValidation'] ) && Functions::serverSupportsFeature(
+				$server,
+				self::$wireVersionForDocumentLevelValidation
+			)
+		) {
+			$bulkOptions['bypassDocumentValidation'] = $this->options['bypassDocumentValidation'];
+		}
 
-        $bulk = new Bulk($bulkOptions);
-        $bulk->update($this->filter, $this->update, $updateOptions);
+		$bulk = new Bulk( $bulkOptions );
+		$bulk->update( $this->filter, $this->update, $updateOptions );
 
-        $writeConcern = isset($this->options['writeConcern']) ? $this->options['writeConcern'] : null;
-        $writeResult = $server->executeBulkWrite(
-            $this->databaseName.'.'.$this->collectionName,
-            $bulk,
-            $writeConcern
-        );
+		$writeConcern = isset( $this->options['writeConcern'] ) ? $this->options['writeConcern'] : null;
+		$writeResult  = $server->executeBulkWrite(
+			$this->databaseName . '.' . $this->collectionName,
+			$bulk,
+			$writeConcern
+		);
 
-        return new UpdateResult($writeResult);
-    }
+		return new UpdateResult( $writeResult );
+	}
 }

--- a/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
+++ b/Library/Phalcon/Db/Adapter/MongoDB/Operation/Update.php
@@ -135,6 +135,9 @@ class Update implements Executable
             'multi' =>$this->options['multi'],
             'upsert'=>$this->options['upsert'],
         ];
+      
+        if(isset($this->options['arrayFilters']))
+		      $updateOptions['arrayFilters'] = $this->options['arrayFilters'];
 
         $bulkOptions=[];
 


### PR DESCRIPTION
Add option arrayFilters to allow to use the arrayfilters of version 3.6 of Mongo.

https://docs.mongodb.com/manual/reference/command/update/#update-command-arrayfilters
https://docs.mongodb.com/php-library/current/reference/method/MongoDBCollection-updateMany/

Hello!

* Type: bug fix | new feature | code quality | documentation
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/incubator/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Thanks
