### PR TITLE
[Oracle] Added missing sharedlock Method (HTTP 500 otherwise)

### DIFF
--- a/Library/Phalcon/Db/Dialect/Oracle.php
+++ b/Library/Phalcon/Db/Dialect/Oracle.php
@@ -59,7 +59,8 @@ class Oracle extends Dialect
      * @param string $sqlQuery
      * @return string
      */
-    public function sharedLock($sqlQuery) {
+    public function sharedLock($sqlQuery)
+    {
         return $sqlQuery . ' LOCK IN SHARE MODE';
     }
 

--- a/Library/Phalcon/Db/Dialect/Oracle.php
+++ b/Library/Phalcon/Db/Dialect/Oracle.php
@@ -54,6 +54,16 @@ class Oracle extends Dialect
     // @codingStandardsIgnoreEnd
 
     /**
+     * Returns a SQL modified with a LOCK IN SHARE MODE clause
+     *
+     * @param string $sqlQuery
+     * @return string
+     */
+    public function sharedLock($sqlQuery) {
+        return $sqlQuery . ' LOCK IN SHARE MODE';
+    }
+
+    /**
      * Generates the SQL for LIMIT clause.
      *
      * @param string $sqlQuery


### PR DESCRIPTION
Hello!

* Type: bug fix

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/incubator/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR. (Existing test for Oracle can be used)

## Description
Since the DialectInterface implemented a new method `sharedLock`, the Oracle Dialect was not working anymore, because it misses the interface method `sharedLock` resulting in a HTTP 500 Server error when trying to query from the database.

```
PHP Fatal error:  Class Phalcon\\Db\\Dialect\\Oracle contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Phalcon\\Db\\DialectInterface::sharedLock)
```

## Closes
#879


