### PR TITLE
Provider Curl setOptions url fix

### DIFF
--- a/Library/Phalcon/Http/Client/Provider/Curl.php
+++ b/Library/Phalcon/Http/Client/Provider/Curl.php
@@ -400,9 +400,11 @@ class Curl extends Request
 
     public function post($uri, $params = [], $useEncoding = true, $customHeader = [], $fullResponse = false)
     {
+        $uri = $this->resolveUri($uri);
+
         $this->setOptions(
             [
-                CURLOPT_URL           => $this->resolveUri($uri),
+                CURLOPT_URL           => $uri->build(),
                 CURLOPT_POST          => true,
                 CURLOPT_CUSTOMREQUEST => Method::POST,
             ]
@@ -415,9 +417,11 @@ class Curl extends Request
 
     public function put($uri, $params = [], $useEncoding = true, $customHeader = [], $fullResponse = false)
     {
+        $uri = $this->resolveUri($uri);
+
         $this->setOptions(
             [
-                CURLOPT_URL           => $this->resolveUri($uri),
+                CURLOPT_URL           => $uri->build(),
                 CURLOPT_POST          => true,
                 CURLOPT_CUSTOMREQUEST => Method::PUT,
             ]
@@ -430,9 +434,11 @@ class Curl extends Request
 
     public function patch($uri, $params = [], $useEncoding = true, $customHeader = [], $fullResponse = false)
     {
+        $uri = $this->resolveUri($uri);
+
         $this->setOptions(
             [
-                CURLOPT_URL           => $this->resolveUri($uri),
+                CURLOPT_URL           => $uri->build(),
                 CURLOPT_POST          => true,
                 CURLOPT_CUSTOMREQUEST => Method::PATCH,
             ]


### PR DESCRIPTION
Fixing "curl_setopt_array(): Array keys must be CURLOPT constants or equivalent integer values ..."

Hello!

* Type: bug fix | new feature | code quality | documentation
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/incubator/blob/master/CONTRIBUTING.md)?
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Thanks
