### PR TITLE
Twig 3.0 compatibility

### DIFF
--- a/Library/Phalcon/Mvc/View/Engine/Twig.php
+++ b/Library/Phalcon/Mvc/View/Engine/Twig.php
@@ -5,6 +5,8 @@ use Phalcon\DiInterface;
 use Phalcon\Mvc\View\Engine;
 use Phalcon\Mvc\View\EngineInterface;
 use Phalcon\Mvc\ViewBaseInterface;
+use Twig\Loader\FilesystemLoader;
+use Twig\TwigFunction;
 
 /**
  * Phalcon\Mvc\View\Engine\Twig
@@ -31,7 +33,7 @@ class Twig extends Engine implements EngineInterface
         $options = [],
         $userFunctions = []
     ) {
-        $loader = new \Twig_Loader_Filesystem(
+        $loader = new FilesystemLoader(
             $view->getViewsDir()
         );
 
@@ -58,168 +60,168 @@ class Twig extends Engine implements EngineInterface
         $options = ['is_safe' => ['html']];
 
         $functions = [
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'content',
                 function () use ($view) {
                     return $view->getContent();
                 },
                 $options
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'partial',
                 function ($partialPath, $params = null) use ($view) {
                     return $view->partial($partialPath, $params);
                 },
                 $options
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'linkTo',
                 function ($parameters, $text = null, $local = true) {
                     return \Phalcon\Tag::linkTo($parameters, $text, $local);
                 },
                 $options
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'textField',
                 function ($parameters) {
                     return \Phalcon\Tag::textField($parameters);
                 },
                 $options
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'passwordField',
                 function ($parameters) {
                     return \Phalcon\Tag::passwordField($parameters);
                 },
                 $options
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'hiddenField',
                 function ($parameters) {
                     return \Phalcon\Tag::hiddenField($parameters);
                 },
                 $options
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'fileField',
                 function ($parameters) {
                     return \Phalcon\Tag::fileField($parameters);
                 },
                 $options
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'checkField',
                 function ($parameters) {
                     return \Phalcon\Tag::checkField($parameters);
                 },
                 $options
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'radioField',
                 function ($parameters) {
                     return \Phalcon\Tag::radioField($parameters);
                 },
                 $options
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'submitButton',
                 function ($parameters) {
                     return \Phalcon\Tag::submitButton($parameters);
                 },
                 $options
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'selectStatic',
                 function ($parameters, $data = []) {
                     return \Phalcon\Tag::selectStatic($parameters, $data);
                 },
                 $options
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'select',
                 function ($parameters, $data = []) {
                     return \Phalcon\Tag::select($parameters, $data);
                 },
                 $options
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'textArea',
                 function ($parameters) {
                     return \Phalcon\Tag::textArea($parameters);
                 },
                 $options
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'form',
                 function ($parameters = []) {
                     return \Phalcon\Tag::form($parameters);
                 },
                 $options
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'endForm',
                 function () {
                     return \Phalcon\Tag::endForm();
                 },
                 $options
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'getTitle',
                 function () {
                     return \Phalcon\Tag::getTitle();
                 },
                 $options
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'stylesheetLink',
                 function ($parameters = null, $local = true) {
                     return \Phalcon\Tag::stylesheetLink($parameters, $local);
                 },
                 $options
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'javascriptInclude',
                 function ($parameters = null, $local = true) {
                     return \Phalcon\Tag::javascriptInclude($parameters, $local);
                 },
                 $options
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'image',
                 function ($parameters = null, $local = true) {
                     return \Phalcon\Tag::image($parameters, $local);
                 },
                 $options
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'friendlyTitle',
                 function ($text, $separator = "-", $lc = true, $replace = null) {
                     return \Phalcon\Tag::friendlyTitle($text, $separator, $lc, $replace);
                 },
                 $options
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'getDocType',
                 function () {
                     return \Phalcon\Tag::getDocType();
                 },
                 $options
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'getSecurityToken',
                 function () use ($di) {
                     return $di->get("security")->getToken();
                 },
                 $options
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'getSecurityTokenKey',
                 function () use ($di) {
                     return $di->get("security")->getTokenKey();
                 },
                 $options
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'url',
                 function ($route) use ($di) {
                     return $di->get("url")->get($route);

--- a/Library/Phalcon/Mvc/View/Engine/Twig/CoreExtension.php
+++ b/Library/Phalcon/Mvc/View/Engine/Twig/CoreExtension.php
@@ -19,12 +19,15 @@
 
 namespace Phalcon\Mvc\View\Engine\Twig;
 
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
 /**
  * \Phalcon\Mvc\View\Engine\Twig\CoreExtension
  * Core extension for Twig engine.
  * Currently supports only work with \Phalcon\Assets\Manager.
  */
-class CoreExtension extends \Twig_Extension
+class CoreExtension extends AbstractExtension
 {
     /**
      * {@inheritdoc}
@@ -50,12 +53,12 @@ class CoreExtension extends \Twig_Extension
         ];
 
         return [
-            'assetsOutputCss' => new \Twig_SimpleFunction(
+            'assetsOutputCss' => new TwigFunction(
                 'assetsOutputCss',
                 [$this, 'functionAssetsOutputCss'],
                 $options
             ),
-            'assetsOutputJs' => new \Twig_SimpleFunction(
+            'assetsOutputJs' => new TwigFunction(
                 'assetsOutputJs',
                 [$this, 'functionAssetsOutputJs'],
                 $options

--- a/Library/Phalcon/Mvc/View/Engine/Twig/Environment.php
+++ b/Library/Phalcon/Mvc/View/Engine/Twig/Environment.php
@@ -20,12 +20,13 @@
 namespace Phalcon\Mvc\View\Engine\Twig;
 
 use Phalcon\DiInterface;
+use Twig\Loader\LoaderInterface;
 
 /**
  * \Phalcon\Mvc\View\Engine\Twig\Environment
  * Twig environment that uses internal dependency injector.
  */
-class Environment extends \Twig_Environment
+class Environment extends \Twig\Environment
 {
     /**
      * Internal dependency injector.
@@ -38,10 +39,10 @@ class Environment extends \Twig_Environment
      * {@inheritdoc}
      *
      * @param \Phalcon\DiInterface  $di
-     * @param \Twig_LoaderInterface $loader
+     * @param \Twig\Loader\LoaderInterface $loader
      * @param array                 $options
      */
-    public function __construct(DiInterface $di, \Twig_LoaderInterface $loader = null, $options = [])
+    public function __construct(DiInterface $di, LoaderInterface $loader = null, $options = [])
     {
         $this->di = $di;
 

--- a/Library/Phalcon/Mvc/View/Engine/Twig/Nodes/Assets.php
+++ b/Library/Phalcon/Mvc/View/Engine/Twig/Nodes/Assets.php
@@ -19,18 +19,21 @@
 
 namespace Phalcon\Mvc\View\Engine\Twig\Nodes;
 
+use Twig\Compiler;
+use Twig\Node\Node;
+
 /**
  * \Phalcon\Mvc\View\Engine\Twig\Nodes\Assets
  * Twig node object that compiles "assets" tag in template.
  */
-class Assets extends \Twig_Node
+class Assets extends Node
 {
     /**
      * {@inheritdoc}
      *
-     * @param \Twig_Compiler $compiler
+     * @param \Twig\Compiler $compiler
      */
-    public function compile(\Twig_Compiler $compiler)
+    public function compile(Compiler $compiler)
     {
         $compiler->addDebugInfo($this)
             ->write('$this->env->getDI()->get(\'assets\')->')

--- a/Library/Phalcon/Mvc/View/Engine/Twig/TokenParsers/Assets.php
+++ b/Library/Phalcon/Mvc/View/Engine/Twig/TokenParsers/Assets.php
@@ -20,6 +20,8 @@
 namespace Phalcon\Mvc\View\Engine\Twig\TokenParsers;
 
 use Phalcon\Mvc\View\Engine\Twig\Nodes\Assets as Node;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
 
 /**
  * \Phalcon\Mvc\View\Engine\Twig\TokenParsers\Assets
@@ -30,20 +32,20 @@ use Phalcon\Mvc\View\Engine\Twig\Nodes\Assets as Node;
  *  {% assets addJs('js/jquery.js') %}
  *  {% assets addJs('js/bootstrap.min.js') %}
  */
-class Assets extends \Twig_TokenParser
+class Assets extends AbstractTokenParser
 {
     /**
      * {@inheritdoc}
      *
-     * @param  \Twig_Token         $token
-     * @return \Twig_NodeInterface
+     * @param  \Twig\Token         $token
+     * @return \Twig\Node\Node
      */
-    public function parse(\Twig_Token $token)
+    public function parse(Token $token)
     {
-        $methodName = $this->parser->getStream()->expect(\Twig_Token::NAME_TYPE)->getValue();
+        $methodName = $this->parser->getStream()->expect(Token::NAME_TYPE)->getValue();
         $arguments = $this->parser->getExpressionParser()->parseArguments();
 
-        $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
+        $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
 
         return new Node(
             ['arguments' => $arguments],

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "sergeyklay/aerospike-php-stubs": "The most complete Aerospike PHP stubs which allows autocomplete in modern IDEs",
         "duncan3dc/fork-helper": "To use extended class to access the beanstalk queue service",
         "swiftmailer/swiftmailer": "~5.2",
-        "twig/twig": "~1.35|~2.0"
+        "twig/twig": "~1.35|~2.0|~3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/incubator/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

The Twig function calls were using the deprecated names, which have been removed in Twig 3.0. Those function calls were changed to their recommended replacements.

A functional test was done using the suggested versions of Twig "~1.35|~2.0" as well as 3.0. All three versions generated pages correctly.

Thanks
