### PR TITLE
update PHPUnit UnitTestCase setUp and tearDown signatures

### DIFF
--- a/Library/Phalcon/Test/PHPUnit/UnitTestCase.php
+++ b/Library/Phalcon/Test/PHPUnit/UnitTestCase.php
@@ -32,12 +32,12 @@ abstract class UnitTestCase extends TestCase implements InjectionAwareInterface
 {
     use UnitTestCaseTrait;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->setUpPhalcon();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->tearDownPhalcon();
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/incubator/issues/888

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/incubator/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change: PHPUnit 8+ tests will fail to run if extending Incubator's PHPUnit UnitTestCase. Although this appears to be fixed within phalcon/incubator-test (for phalcon 4.x), there appeared to be no solution on the horizon for incubator 3.x.

Thanks
