### PR TITLE
fix namespace of DiInterface import

### DIFF
--- a/Library/Phalcon/Test/Traits/UnitTestCase.php
+++ b/Library/Phalcon/Test/Traits/UnitTestCase.php
@@ -22,7 +22,7 @@ use Phalcon\Di;
 use Phalcon\Config;
 use Phalcon\Di\FactoryDefault;
 use Phalcon\Di\InjectionAwareInterface;
-use Phalcon\DiInterface;
+use Phalcon\Di\DiInterface;
 use Phalcon\Escaper;
 use Phalcon\Mvc\Url;
 use Phalcon\Test\Traits\ResultSet;


### PR DESCRIPTION
Hello!

* Type: bug fix
` Declaration of Phalcon\Test\PHPUnit\UnitTestCase::setDI(Phalcon\DiInterface $di) must be compatible with Phalcon\Di\InjectionAwareInterface::setDI(Phalcon\Di\DiInterface $container): void`

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/incubator/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:
I fixed the namespace :)