### PR TITLE
Updated declaration of MysqlExtended::getSqlExpresion for Phalcon v4

### DIFF
--- a/Library/Phalcon/Db/Dialect/MysqlExtended.php
+++ b/Library/Phalcon/Db/Dialect/MysqlExtended.php
@@ -57,7 +57,7 @@ class MysqlExtended extends Mysql
      *
      * @throws Exception
      */
-    public function getSqlExpression(array $expression, $escapeChar = null, $bindCounts = null)
+    public function getSqlExpression(array $expression, ?string $escapeChar = null, $bindCounts = null): string
     {
         if ($expression["type"] == 'functionCall') {
             $expressionName = strtoupper($expression["name"]);


### PR DESCRIPTION
Bug fix for fatal error:

> PHP Fatal error:  Declaration of Phalcon\Db\Dialect\MysqlExtended::getSqlExpression(array $expression, $escapeChar = NULL, $bindCounts = NULL) must be compatible with Phalcon\Db\Dialect::getSqlExpression(array $expression, ?string $escapeChar = NULL, $bindCounts = NULL): string in /vendor/phalcon/incubator/Library/Phalcon/Db/Dialect/MysqlExtended.php on line 60

Using Phalcon 4.1.2, PHP 7.4.