### PR TITLE
Truncate table on flush

### DIFF
--- a/Library/Phalcon/Cache/Backend/Database.php
+++ b/Library/Phalcon/Cache/Backend/Database.php
@@ -334,7 +334,7 @@ class Database extends Backend implements BackendInterface
      */
     public function flush()
     {
-        $this->db->execute("DELETE FROM {$this->table}");
+        $this->db->execute("TRUNCATE TABLE {$this->table}");
 
         return true;
     }

--- a/tests/unit/Cache/Backend/DatabaseTest.php
+++ b/tests/unit/Cache/Backend/DatabaseTest.php
@@ -128,7 +128,11 @@ class DatabaseTest extends Test
             $backend->delete($this->key)
         );
 
+        $backend->save('key1', $this->data, $lifetime);
+        $backend->save('key2', $this->data, $lifetime);
 
+        $this->assertTrue($backend->flush());
+        $this->assertEmpty($backend->queryKeys());
 
         if (null !== $lifetime) {
             $backend->save($this->key, $this->data, $lifetime);


### PR DESCRIPTION
Hello!

* Type: code quality
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/incubator/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:
Better to use truncate on table flush

Thanks
